### PR TITLE
fix: use preflight in the document

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,5 +1,6 @@
 @font-face{font-family:Finntype;font-style:normal;font-weight:400;src:url("https://static.finncdn.no/_c/static/fonts/FINNTypeStrippet-Light.woff2") format("woff2")}
 @font-face{font-family:Finntype;font-style:normal;font-weight:700;src:url("https://static.finncdn.no/_c/static/fonts/FINNTypeStrippet-Medium.woff2") format("woff2")}
+@unocss-placeholder
 :root {
   --vp-c-brand: #2b7eff;
   --vp-c-brand-dark: #0063fb;

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -3,8 +3,6 @@ import ApiTable from '../ApiTable.vue';
 import ThemeSwitcher from '../ThemeSwitcher.vue';
 import '../bootExamples.js';
 import './custom.css';
-import '@warp-ds/component-classes/common'
-
 
 export default {
   ...DefaultTheme,

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "vitepress build docs"
   },
   "devDependencies": {
-    "@warp-ds/component-classes": "1.0.0-alpha.20",
-    "@warp-ds/uno": "^1.0.0-alpha.5",
+    "@warp-ds/component-classes": "1.0.0-alpha.33",
+    "@warp-ds/uno": "^1.0.0-alpha.6",
     "@warp-ds/vue": "^1.0.0-alpha.6",
     "markdown-it": "^13.0.1",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,8 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@warp-ds/component-classes': 1.0.0-alpha.20
-  '@warp-ds/uno': ^1.0.0-alpha.5
+  '@warp-ds/component-classes': 1.0.0-alpha.33
+  '@warp-ds/uno': ^1.0.0-alpha.6
   '@warp-ds/vue': ^1.0.0-alpha.6
   markdown-it: ^13.0.1
   react: ^18.2.0
@@ -13,8 +13,8 @@ specifiers:
   vue: ^3.2.47
 
 devDependencies:
-  '@warp-ds/component-classes': 1.0.0-alpha.20
-  '@warp-ds/uno': 1.0.0-alpha.5
+  '@warp-ds/component-classes': 1.0.0-alpha.33
+  '@warp-ds/uno': 1.0.0-alpha.6
   '@warp-ds/vue': 1.0.0-alpha.6
   markdown-it: 13.0.1
   react: 18.2.0
@@ -870,12 +870,12 @@ packages:
       - vue
     dev: true
 
-  /@warp-ds/component-classes/1.0.0-alpha.20:
-    resolution: {integrity: sha512-vNNW2MFOkP+GPsQ3WfZh8jRhPjXk0jYHSb+aKAcWwlgQLm1DKn3P6yJEKiK/THKInzYpqms/SxmZfZtRk+9fZA==}
+  /@warp-ds/component-classes/1.0.0-alpha.33:
+    resolution: {integrity: sha512-cvLH2ilA8bkevycgfU6973P9GbXSN0ejnNmKnugXWnBRXJmK1wDOot7hU/fxSFzqNkOXiFu9NY3Pk8qkVDlYbA==}
     dev: true
 
-  /@warp-ds/uno/1.0.0-alpha.5:
-    resolution: {integrity: sha512-8V6VuRmYujceUfYkbRkkQsu1EuLLQyRWfbLn9ehz962DXA+oJ4kSnjK12tdc2tNI/8EKs14Tl4c3X4e/d+1S/w==}
+  /@warp-ds/uno/1.0.0-alpha.6:
+    resolution: {integrity: sha512-vVxd33VHmefTLQFKGXT1Pw2q+ZdnUqgCKlVZryX9LaiHfHAkxVNmMsWucJFvMr98SXbsPLydSzqqKbqTkzcvLg==}
     dependencies:
       '@unocss/core': 0.50.8
       '@unocss/preset-mini': 0.50.8


### PR DESCRIPTION
We need to use preflight on the document level to get whatever we want to set for e.g. `html`. 