### PR TITLE
fix: add better examples for textfield and textarea

### DIFF
--- a/docs/.vitepress/ex-base.js
+++ b/docs/.vitepress/ex-base.js
@@ -6,7 +6,17 @@ export const buildWc = (elementName, baseVueComponent) => {
     connectedCallback() {
       const warp = `<link rel="stylesheet" type="text/css" href='https://assets.finn.no/pkg/@warp-ds/tokens/v1/finn-no.css' />`
       const target = `<div id="app" class="mt-16"></div>`
-      const shadowUnoStyle = `<style>@unocss-placeholder</style>`
+      const shadowUnoStyle = `<style>
+        @unocss-placeholder
+        h3 {
+          font-weight: bold;
+        }
+        .component {
+          padding: 16px;
+          border: 3px solid rgb(246, 248, 250);
+          margin-bottom: 8px;
+        }
+      </style>`
       
       this.shadow = this.attachShadow({ mode: 'open' })
       this.shadow.innerHTML = warp + shadowUnoStyle + target    

--- a/docs/textarea/Example.vue
+++ b/docs/textarea/Example.vue
@@ -4,4 +4,24 @@
 
 <template>
   <w-textarea label="A label" hint="A hint" v-model="model" />
+  <h3>Standard with hint</h3>
+  <div class="component">
+    <w-textarea label="A label" hint="A hint" />
+  </div>
+  <h3>Optional</h3>
+  <div class="component">
+    <w-textarea label="A label" optional />
+  </div>
+  <h3>Disabled</h3>
+  <div class="component">
+    <w-textarea label="A label" disabled />
+  </div>
+  <h3>Read Only</h3>
+  <div class="component">
+    <w-textarea label="A label" value="This is a readOnly textarea" readOnly />
+  </div>
+  <h3>Invalid</h3>
+  <div class="component">
+    <w-textarea label="A label" invalid required />
+  </div>
 </template>

--- a/docs/textfield/Example.vue
+++ b/docs/textfield/Example.vue
@@ -1,8 +1,37 @@
 <script setup>
   import { wInput } from '@warp-ds/vue';
+  import { wAffix } from '@warp-ds/vue';
 
 </script>
 
 <template>
-  <w-input label="A label" hint="A hint" v-model="model" />
+  <h3>Standard with hint</h3>
+  <div class="component">
+    <w-input label="A label" hint="A hint" />
+  </div>
+  <h3>Optional with placeholder</h3>
+  <div class="component">
+    <w-input label="A label" placeholder="This is a placeholder" optional />
+  </div>
+  <h3>Disabled</h3>
+  <div class="component">
+    <w-input label="A label" disabled />
+  </div>
+  <h3>Read Only</h3>
+  <div class="component">
+    <w-input label="A label" value="This is a readOnly textfield" readOnly />
+  </div>
+  <h3>Invalid</h3>
+  <div class="component">
+    <w-input label="A label" #suffix invalid required >
+      <w-affix suffix clear />
+    </w-input>
+  </div>
+  <h3>Suffix + Prefix</h3>
+  <div class="component">
+    <w-input label="A label" #prefix #suffix  >
+      <w-affix suffix clear />
+      <w-affix prefix label="kr" />
+    </w-input>
+  </div>
 </template>


### PR DESCRIPTION
Before|After
---|---
![image](https://user-images.githubusercontent.com/37986637/233024303-597aa9dd-697d-43ab-b372-507d2b0b14b3.png) | <img width="642" alt="image" src="https://user-images.githubusercontent.com/37986637/233024447-1ad32351-16e2-4f76-8614-8f4459c237d8.png">
![image](https://user-images.githubusercontent.com/37986637/233024622-48174b80-589d-474b-b8ee-76c4ea0f115c.png)|<img width="606" alt="image" src="https://user-images.githubusercontent.com/37986637/233024541-d7feb333-44f7-46c7-b42e-c339a9390da5.png">


