### PR TITLE
feat: add controls for showing different component variants

### DIFF
--- a/docs/.vitepress/Control.vue
+++ b/docs/.vitepress/Control.vue
@@ -1,0 +1,14 @@
+<script setup>
+import { wButtonGroup } from '@warp-ds/vue';
+import ControlItem from './ControlItem.vue';
+defineProps({ state: null, controls: Array, label: String });
+</script>
+
+<template>
+  <div>
+    <h3 class="text-12 font-bold" v-if="label">{{ label }}</h3>
+    <w-button-group outlined>
+      <control-item v-for="c in controls" v-bind="c" :state="state" />
+    </w-button-group>
+  </div>
+</template>

--- a/docs/.vitepress/ControlItem.vue
+++ b/docs/.vitepress/ControlItem.vue
@@ -1,0 +1,30 @@
+<script>
+export default { inheritAttrs: false }
+</script>
+
+<script setup>
+import { wButtonGroupItem, wClickable } from '@warp-ds/vue';
+import { computed } from 'vue';
+
+const props = defineProps({
+  state: null,
+  name: String,
+  radio: Boolean,
+  checkbox: Boolean,
+  button: Boolean
+});
+
+const stateLocation = computed(() => props.radio ? 'active' : props.name);
+const model = props.button ? null : computed({
+  get: () => props.state[stateLocation.value],
+  set: v => props.state[stateLocation.value] = v
+})
+const selected = props.button ? null : computed(() => props.radio ? model.value === props.name : model.value);
+</script>
+
+<template>
+  <w-button-group-item :selected="selected">
+    <w-clickable v-if="button" label v-bind="$attrs">{{ name }}</w-clickable>
+    <w-clickable v-else label v-bind="$props" v-model="model" :value="name">{{ name }}</w-clickable>
+  </w-button-group-item>
+</template>

--- a/docs/.vitepress/Controls.vue
+++ b/docs/.vitepress/Controls.vue
@@ -1,0 +1,10 @@
+<script setup>
+import { wBox } from '@warp-ds/vue';
+defineProps({ x: Boolean, y: Boolean });
+</script>
+
+<template>
+  <w-box neutral :class="{ 'space-y-24': y, 'space-x-24': x }">
+    <slot />
+  </w-box>
+</template>

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -3,6 +3,9 @@ import { presetWarp } from '@warp-ds/uno';
 import uno from 'unocss/vite';
 import { classes } from '@warp-ds/component-classes/classes';
 
+// Classes of documentation-related elements used within Warp component examples
+const docsClasses = ['text-12', 'font-bold', 'space-y-24', 'space-x-24']
+
 export default defineConfig({
   lang: 'en-US',
   title: 'Warp Tech',
@@ -23,7 +26,7 @@ export default defineConfig({
       uno({
         presets: [presetWarp({ usePreflight: true })],
         mode: 'shadow-dom',
-        safelist: classes,
+        safelist: [...classes, ...docsClasses],
       }),
     ],
   },
@@ -95,7 +98,10 @@ export default defineConfig({
             {
               text: 'Actions',
               collapsible: true,
-              items: [{ text: 'Button', link: '/components/buttons/' }],
+              items: [
+                { text: 'Button', link: '/components/buttons/' },
+                { text: 'Button Group', link: '/components/buttongroup/' }
+              ],
             },
             {
               text: 'Forms',

--- a/docs/.vitepress/ex-base.js
+++ b/docs/.vitepress/ex-base.js
@@ -1,4 +1,6 @@
 import { createApp } from 'vue';
+import Control from './Control.vue';
+import Controls from './Controls.vue';
 
 export const buildWc = (elementName, baseVueComponent) => {
   if (typeof window === 'undefined') return;
@@ -31,7 +33,10 @@ export const buildWc = (elementName, baseVueComponent) => {
 
           this.shadow = this.attachShadow({ mode: 'open' });
           this.shadow.innerHTML = shadowUnoStyle + warp + target;
-          createApp(baseVueComponent).mount(this.appEl);
+          createApp(baseVueComponent)
+          .component('demo-control', Control)
+          .component('demo-controls', Controls)
+          .mount(this.appEl);
           document.addEventListener('change', () => {
             if (window.theme) {
               const stylesheets = this.shadow.querySelectorAll('link');

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "build": "vitepress build docs"
   },
   "devDependencies": {
-    "@warp-ds/component-classes": "1.0.0-alpha.56",
-    "@warp-ds/uno": "^1.0.0-alpha.8",
-    "@warp-ds/vue": "^1.0.0-alpha.17",
+    "@warp-ds/component-classes": "1.0.0-alpha.59",
+    "@warp-ds/uno": "^1.0.0-alpha.19",
+    "@warp-ds/vue": "^1.0.0-alpha.18",
     "markdown-it": "^13.0.1",
     "react": "^18.2.0",
     "sass": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "build": "vitepress build docs"
   },
   "devDependencies": {
-    "@warp-ds/component-classes": "1.0.0-alpha.48",
+    "@warp-ds/component-classes": "1.0.0-alpha.56",
     "@warp-ds/uno": "^1.0.0-alpha.8",
-    "@warp-ds/vue": "^1.0.0-alpha.15",
+    "@warp-ds/vue": "^1.0.0-alpha.17",
     "markdown-it": "^13.0.1",
     "react": "^18.2.0",
     "sass": "^1.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,14 +2,14 @@ lockfileVersion: '6.0'
 
 devDependencies:
   '@warp-ds/component-classes':
-    specifier: 1.0.0-alpha.48
-    version: 1.0.0-alpha.48
+    specifier: 1.0.0-alpha.56
+    version: 1.0.0-alpha.56
   '@warp-ds/uno':
     specifier: ^1.0.0-alpha.8
     version: 1.0.0-alpha.8
   '@warp-ds/vue':
-    specifier: ^1.0.0-alpha.15
-    version: 1.0.0-alpha.15
+    specifier: ^1.0.0-alpha.17
+    version: 1.0.0-alpha.17
   markdown-it:
     specifier: ^13.0.1
     version: 13.0.1
@@ -21,7 +21,7 @@ devDependencies:
     version: 1.60.0
   unocss:
     specifier: ^0.51.3
-    version: 0.51.3(vite@4.2.1)
+    version: 0.51.3(postcss@8.4.21)(vite@4.2.1)
   vite:
     specifier: ^4.2.1
     version: 4.2.1(sass@1.60.0)
@@ -620,9 +620,11 @@ packages:
       sirv: 2.0.2
     dev: true
 
-  /@unocss/postcss@0.51.3:
+  /@unocss/postcss@0.51.3(postcss@8.4.21):
     resolution: {integrity: sha512-ZXfkapLfK5813nI08pCOpCykdNObcX8u6uS5eaBJl84ndYUAW55Kbva1vnqxiiDORmBXmlxHo1iRHZi6/iGGxA==}
     engines: {node: '>=14'}
+    peerDependencies:
+      postcss: ^8.4.21
     dependencies:
       '@unocss/config': 0.51.3
       '@unocss/core': 0.51.3
@@ -878,8 +880,8 @@ packages:
       - vue
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.48:
-    resolution: {integrity: sha512-/PXFf0UP2XdmMhewlmUO4I/7yTT92cqw+cozKNpZt9k/r3rxH28uXHkqK+O9/imk7/7HdiT21cTARwiIsdX81g==}
+  /@warp-ds/component-classes@1.0.0-alpha.56:
+    resolution: {integrity: sha512-a4yR3POi+2xCQHM/qkimJbSYqz5HfzxFjKxuEypV6B/Wu+0u+lmRn9hWQUc0yPQ6DhbeGTwN0A0X2Rb4ZewbEA==}
     dev: true
 
   /@warp-ds/uno@1.0.0-alpha.8:
@@ -889,8 +891,8 @@ packages:
       '@unocss/preset-mini': 0.50.8
     dev: true
 
-  /@warp-ds/vue@1.0.0-alpha.15:
-    resolution: {integrity: sha512-oJH/fbwBN8k3mO31YnfqhDu9xGMxNgXeKwBZg2KPDPJxssIUCeXZiO0WDa+tc3kWK7bGa8QM5OUfrcL7iTTsgw==}
+  /@warp-ds/vue@1.0.0-alpha.17:
+    resolution: {integrity: sha512-E7U3WhMqjaQv7WZD80ou97C96NSgEe79cEbh4KiwrXvF+Xjq3tGazFUKMUqWQY5aljjgWSusHa6KiO96Nt0tTQ==}
     dependencies:
       '@fabric-ds/core': 0.0.15
       '@fabric-ds/css': 1.2.0
@@ -1585,7 +1587,7 @@ packages:
       jiti: 1.18.2
     dev: true
 
-  /unocss@0.51.3(vite@4.2.1):
+  /unocss@0.51.3(postcss@8.4.21)(vite@4.2.1):
     resolution: {integrity: sha512-iQ1ftflPKe9U68sOzyqA9QL00xschvmer6YprYNWOJxPTOf0Mw/jTaLGoS1ZF/lDIaC4nae6h479S8k0DzysXw==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -1598,7 +1600,7 @@ packages:
       '@unocss/cli': 0.51.3
       '@unocss/core': 0.51.3
       '@unocss/extractor-arbitrary-variants': 0.51.3
-      '@unocss/postcss': 0.51.3
+      '@unocss/postcss': 0.51.3(postcss@8.4.21)
       '@unocss/preset-attributify': 0.51.3
       '@unocss/preset-icons': 0.51.3
       '@unocss/preset-mini': 0.51.3
@@ -1615,6 +1617,7 @@ packages:
       '@unocss/transformer-variant-group': 0.51.3
       '@unocss/vite': 0.51.3(vite@4.2.1)
     transitivePeerDependencies:
+      - postcss
       - rollup
       - supports-color
       - vite

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,14 +2,14 @@ lockfileVersion: '6.0'
 
 devDependencies:
   '@warp-ds/component-classes':
-    specifier: 1.0.0-alpha.56
-    version: 1.0.0-alpha.56
+    specifier: 1.0.0-alpha.59
+    version: 1.0.0-alpha.59
   '@warp-ds/uno':
-    specifier: ^1.0.0-alpha.8
-    version: 1.0.0-alpha.8
+    specifier: ^1.0.0-alpha.19
+    version: 1.0.0-alpha.19
   '@warp-ds/vue':
-    specifier: ^1.0.0-alpha.17
-    version: 1.0.0-alpha.17
+    specifier: ^1.0.0-alpha.18
+    version: 1.0.0-alpha.18
   markdown-it:
     specifier: ^13.0.1
     version: 13.0.1
@@ -880,19 +880,19 @@ packages:
       - vue
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.56:
-    resolution: {integrity: sha512-a4yR3POi+2xCQHM/qkimJbSYqz5HfzxFjKxuEypV6B/Wu+0u+lmRn9hWQUc0yPQ6DhbeGTwN0A0X2Rb4ZewbEA==}
+  /@warp-ds/component-classes@1.0.0-alpha.59:
+    resolution: {integrity: sha512-hJjf9mUH3EpklasSH1h152Kh85L9HTuXcpA+MRghBYGUM02/6rbtKDLMlLj4+ZGr6UVrRgjizSPMEIafXrC4hg==}
     dev: true
 
-  /@warp-ds/uno@1.0.0-alpha.8:
-    resolution: {integrity: sha512-OcrvcdtzlDtV+v1qTb6nLdK5xFdZNJDL3txYOvnNBXrmr7Jx7cmiMIRctZxkLsjSLA4HGVo5NlNWakHeWawSmw==}
+  /@warp-ds/uno@1.0.0-alpha.19:
+    resolution: {integrity: sha512-wUbsj+y5TroA09csPAvGYzEGXzIljLNnp4fBIgGnnXKYsPyZOxHsZYG4CV48zeK934M1E7IdmkJWRn49L0PxCA==}
     dependencies:
       '@unocss/core': 0.50.8
       '@unocss/preset-mini': 0.50.8
     dev: true
 
-  /@warp-ds/vue@1.0.0-alpha.17:
-    resolution: {integrity: sha512-E7U3WhMqjaQv7WZD80ou97C96NSgEe79cEbh4KiwrXvF+Xjq3tGazFUKMUqWQY5aljjgWSusHa6KiO96Nt0tTQ==}
+  /@warp-ds/vue@1.0.0-alpha.18:
+    resolution: {integrity: sha512-jsmOwh6BPenGKVeyiWNZiqXZLstsED/CQAH7FLOXNRWOHMsPQUgt9c8amyx6g08F19OeF2VQKqjpxbqkFuWdgA==}
     dependencies:
       '@fabric-ds/core': 0.0.15
       '@fabric-ds/css': 1.2.0


### PR DESCRIPTION
Depends on https://github.com/warp-ds/vue/pull/25.

These controls will be used in the button group docs but can be used elsewhere within component examples. The output should look like this:
<img width="345" alt="Screenshot 2023-05-08 at 14 23 49" src="https://user-images.githubusercontent.com/41303231/236822963-89cd3181-66b2-43f7-b12b-3a10e07b414d.png">


...when used with these settings:
```
<script setup>
import { reactive } from 'vue';

const buildCheckboxState = ({ controls, active }) => controls.reduce((acc, e) => (acc[e.name] = e.name === active, acc), {});
const type = reactive({ active: 'Radio' });

const typeControls = [
  { name: 'Radio', radio: true },
  { name: 'Button', radio: true },
]
const modifierControls = [
  { name: 'Outlined', checkbox: true },
  { name: 'Raised', checkbox: true },
  { name: 'Vertical', checkbox: true },
]

const modifiers = reactive(buildCheckboxState({ controls: modifierControls }))
</script>

<template>
   <demo-controls y>
      <demo-control label="Type" :controls="typeControls" :state="type" />
      <demo-control label="Modifiers" :controls="modifierControls" :state="modifiers" />
    </demo-controls>
</template>
```