### PR TITLE
fix: suggest installing alpha versions of @warp-ds deps

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -16,8 +16,10 @@ Ensure your project is integrated with UnoCSS and Warp.
 
 #### Install
 
+`alpha` versions of @warp-ds packages should be installed until major versions are available.
+
 ```shell
-npm install -D unocss @warp-ds/uno
+npm install -D unocss @warp-ds/uno@alpha @warp-ds/component-classes@alpha
 ```
 
 > Webpack based projects should also add: `@unocss/webpack` (see [UnoCSS docs](https://unocss.dev/integrations/webpack) for more information)


### PR DESCRIPTION
## Issue
Installing dependencies like `@warp-ds/uno` and `@warp-ds/component-classes` doesn’t point to the latest versions of those packages due to `latest` flag pointing at much older versions. 

## Solution
One solution would be to manipulate the tags to point however we want so we could point "latest" to whichever specific version we prefer. 
We went for a quick solution which is to ask users to install @alpha versions of those packages until a major version is out for each of them.