### PR TITLE
Suggest setting usePreflight to true in presetWarp config

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -30,7 +30,7 @@ npm install -D unocss @warp-ds/uno@alpha @warp-ds/component-classes@alpha
 
 #### Configure
 
-Create a `uno.config.js` file with the following content. This file will configure UnoCSS with our Warp preset, including a safelist of component classes, which will add styling to Warp components. See all configuration options for `presetWarp` in the [Warp CSS docs](https://warp-ds.github.io/css-docs/plugin-api).
+Create a `uno.config.js` file with the following content. This file will configure UnoCSS with our Warp preset, including preflights and a safelist of component classes, which will add styling to Warp components. See all configuration options for `presetWarp` in the [Warp CSS docs](https://warp-ds.github.io/css-docs/plugin-api).
 
 ```js
 import { defineConfig } from 'unocss';
@@ -39,7 +39,7 @@ import { classes } from '@warp-ds/component-classes/classes';
 
 export default defineConfig({
   presets: [
-    presetWarp(),
+    presetWarp({ usePreflight: true }),
     safelist: classes
   ]
 });
@@ -66,7 +66,7 @@ import { presetWarp } from '@warp-ds/uno';
 
 window.__unocss = {
   presets: [
-    presetWarp()
+    presetWarp({ usePreflight: true })
   ],
 };
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -37,7 +37,7 @@ import { presetMigrate } from '@warp-ds/preset-migrate'
 export default defineConfig({
   presets: [
     presetMigrate(),
-    presetWarp()
+    presetWarp({ usePreflight: true })
   ]
 })
 ```


### PR DESCRIPTION
We need to ensure that all sites have the same CSS resets applied. For now this can be done by setting `usePreflight` flag to `true` on `presetWarp`. This way Tailwind, form and typography resets are included in the generated CSS.

It's not clear to me anymore why this flag was introduced in the first place, defaulting the generated CSS to not include the preflights, but me and @Skadefryd believe that preflights should always be included, which may lead to another task, i.e. removing the flag from [@warp-ds/drive](https://github.com/warp-ds/drive). For now however this seems like a quick fix for us.