### PR TITLE
fix: set node version to 'lts' and bump pnpm to 8

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,10 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: lts/*
       - uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
           run_install: true
       - name: Build
         run: pnpm build


### PR DESCRIPTION
Should fix a build error where [fetch is not defined](https://github.com/warp-ds/tech-docs/actions/runs/5198078277/jobs/9373750270#step:5:32). For versions of Node prior to 18, the [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) is not implemented out-of-the-box.

Versions applied are based on [this Slack discussion](https://sch-chat.slack.com/archives/C050N3NQ204/p1682420782915109?thread_ts=1682412782.582729&cid=C050N3NQ204)