### PR TITLE
Add section on semantic colors to migration docs

### DIFF
--- a/docs/migration/colors.md
+++ b/docs/migration/colors.md
@@ -1,0 +1,2 @@
+## Colors in Warp
+In Warp Design System we are changing the whole concept of working with colors. We are no longer picking colors from a palette (like `text-blue-600`), but instead we use colors based on their purpose (like `text-primary`). This is something we do because we need to support theming/dark mode.

--- a/docs/migration/designers/index.md
+++ b/docs/migration/designers/index.md
@@ -56,3 +56,5 @@ Name the file something with Tori so you remember that it’s the **Tori** theme
 6. Click “Swap library.”
 
 And, voila – now you should have something that looks like Tori!
+
+<!--@include: ../colors.md-->

--- a/docs/migration/developers/index.md
+++ b/docs/migration/developers/index.md
@@ -80,3 +80,5 @@ Using the previous example's error as an example, it should be rewritten (f.ex) 
 > This field must be filled out with your 11-digit SSN
 
 and the hint can remain the same.
+
+<!--@include: ../colors.md-->


### PR DESCRIPTION
Co-authored-by: @Skadefryd 

<img width="787" alt="Screenshot 2023-06-14 at 14 35 33" src="https://github.com/warp-ds/tech-docs/assets/41303231/362e7656-c67c-4adc-a11f-94fd14286072">
