### PR TITLE
fix: remove mentions of pnpm

### DIFF
--- a/docs/getting-started/developers/elements.md
+++ b/docs/getting-started/developers/elements.md
@@ -3,14 +3,8 @@
 The Warp Elements package can be installed from NPM.
 `alpha` versions of @warp-ds packages should be installed until major versions are available.
 
-### with npm: 
 ```shell
 npm install @warp-ds/elements@alpha
-```
-
-### with pnpm
-```shell
-pnpm add @warp-ds/elements@alpha
 ```
 
 ## Using Components

--- a/docs/getting-started/developers/index.md
+++ b/docs/getting-started/developers/index.md
@@ -26,16 +26,8 @@ A guide on how to integrate your project with UnoCSS and Warp.
 
 `alpha` versions of @warp-ds packages should be installed until major versions are available.
 
-> With npm:
-
 ```shell
-npm install -D unocss @warp-ds/uno@alpha @warp-ds/component-classes@alpha
-```
-
-> With pnpm
-
-```shell
-pnpm add -D unocss @warp-ds/uno@alpha @warp-ds/component-classes@alpha
+npm install unocss @warp-ds/uno@alpha @warp-ds/component-classes@alpha
 ```
 
 #### If you are using Webpack
@@ -43,7 +35,7 @@ pnpm add -D unocss @warp-ds/uno@alpha @warp-ds/component-classes@alpha
 In addition to the installation of the Warp packages, Webpack based projects should also install `@unocss/webpack`
 
 ```shell
-pnpm add -D @unocss/webpack
+npm install -D @unocss/webpack --save-dev
 ```
 
 See [UnoCSS docs](https://unocss.dev/integrations/webpack) for more information.
@@ -137,7 +129,7 @@ UnoCSS also provides a CSS-in-JS runtime module which runs the UnoCSS engine rig
 #### Bundler usage
 
 ```shell
-pnpm install @unocss/runtime @warp-ds/uno
+npm install @unocss/runtime @warp-ds/uno
 ```
 
 ```js

--- a/docs/getting-started/developers/react.md
+++ b/docs/getting-started/developers/react.md
@@ -3,14 +3,8 @@
 The Warp React package can be installed from NPM.
 `alpha` versions of @warp-ds packages should be installed until major versions are available.
 
-### with npm:
 ```shell
 npm install @warp-ds/react@alpha
-```
-
-### with pnpm
-```shell
-pnpm add @warp-ds/react@alpha
 ```
 
 ## Using Components
@@ -31,5 +25,5 @@ The components are written in TypeScript. To take advantage of this, make sure
 your project is up to date on the latest `@types/react` definitions.
 
 ```shell
-npm install @types/react -D
+npm install @types/react --save-dev
 ```

--- a/docs/getting-started/developers/vue.md
+++ b/docs/getting-started/developers/vue.md
@@ -3,14 +3,8 @@
 The Warp Vue package can be installed from NPM.
 `alpha` versions of @warp-ds packages should be installed until major versions are available.
 
-### with npm:
 ```shell
 npm install @warp-ds/vue@alpha
-```
-
-### with pnpm
-```shell
-pnpm add @warp-ds/vue@alpha
 ```
 
 ## Using Components

--- a/docs/migration/developers/index.md
+++ b/docs/migration/developers/index.md
@@ -30,7 +30,7 @@ The migration plugin is available to use to detect all deprecated CSS classes an
 #### Install the plugin
 
 ```shell
-pnpm add -D @warp-ds/preset-migrate
+npm install @warp-ds/preset-migrate --save-dev
 ```
 
 #### Use the plugin in your Uno config


### PR DESCRIPTION
We should not instruct users to use any other package manager than `npm`. They are free to use `yarn`, `pnpm` or any other tool for installing packages. 

Also, our documentation doesn't need to show how packages can be installed with other package managers, so I removed examples `with npm` and `with pnpm` from the `## Installation` sections. This way the doc got slightly shorter, too 😄 

Finally, I thought I should remove the suggestion to install `@warp-ds/uno` and `uno` as dev dependencies, because that may result in automerging of renovate bot PRs when patch versions of those dependencies change. I think we should live it up to the users to decide what type of dependencies these should be.