### PR TITLE
fix: update button examples

### DIFF
--- a/docs/components/buttons/Example.vue
+++ b/docs/components/buttons/Example.vue
@@ -4,12 +4,12 @@
 
 <template>
     <div class="space-x-8">
-        <w-button primary>Click me</w-button>
-        <w-button primary loading>Click me</w-button>
-        <w-button>Click me</w-button>
-        <w-button secondary quiet>Click me</w-button>
-        <w-button secondary quiet small>Click me</w-button>
-        <w-button primary negative>Click me</w-button>
-        <w-button negative quiet>Click me</w-button>
+        <w-button primary>Primary</w-button>
+        <w-button primary loading>Loading</w-button>
+        <w-button utility>Utility</w-button>
+        <w-button>Secondary</w-button>
+        <w-button secondary quiet>Quiet</w-button>
+        <w-button primary negative>Negative</w-button>
+        <w-button negative quiet>Quiet</w-button>
     </div>
 </template>

--- a/docs/components/buttons/Example.vue
+++ b/docs/components/buttons/Example.vue
@@ -3,13 +3,13 @@
 </script>
 
 <template>
-    <div class="space-x-8">
+    <div class="space-x-8 space-y-16 text-center">
         <w-button primary>Primary</w-button>
         <w-button primary loading>Loading</w-button>
         <w-button utility>Utility</w-button>
         <w-button>Secondary</w-button>
-        <w-button secondary quiet>Quiet</w-button>
+        <w-button secondary quiet>Secondary Quiet</w-button>
         <w-button primary negative>Negative</w-button>
-        <w-button negative quiet>Quiet</w-button>
+        <w-button negative quiet>Negative Quiet</w-button>
     </div>
 </template>


### PR DESCRIPTION
Someone (including me  😄) couldn’t find a utility variant of a button in the tech docs due to some differences in naming between Figma designs and our documentation. I figured it might then make sense to add that variant and update button text in those few examples we have. Eventually we'd create a storybook playground where all possible variants can be found but until then this change might help devs find the right setup for their button component.
<img width="716" alt="Screenshot 2023-08-10 at 13 36 12" src="https://github.com/warp-ds/tech-docs/assets/41303231/0177915a-7e15-4ec9-8eae-f6a9cad2d736">
<img width="714" alt="Screenshot 2023-08-10 at 13 36 23" src="https://github.com/warp-ds/tech-docs/assets/41303231/3c910a6e-e58a-4c09-aa22-be639f4734e3">


