### PR TITLE
fix(textfield): suggest 'invalid' instead of 'error' prop for validation

### DIFF
--- a/docs/components/textfield/elements.md
+++ b/docs/components/textfield/elements.md
@@ -3,8 +3,8 @@
 
 ## Validation
 Text fields can communicate to the user whether the current value is invalid. Implement your
-own validation logic in your app and set the error prop to display it as invalid. <i>error</i> is
-often paired with <i>help-text</i> to provide feedback to the user about the error.
+own validation logic in your app and set the `invalid` attribute to display it as invalid. `invalid` is
+often paired with `help-text` to provide feedback to the user about the error.
 
 ```html
 <w-textfield label="Email" invalid help-text="Ugyldig e-post"></w-textfield>

--- a/docs/components/textfield/react.md
+++ b/docs/components/textfield/react.md
@@ -60,9 +60,9 @@ TextFields can provide additional context with `helpText` if the label and place
 
 ## Validation
 
-TextFields can communicate to the user whether the current value is invalid. Implement your own validation logic in your app and set the error prop to display it as invalid.
+TextFields can communicate to the user whether the current value is invalid. Implement your own validation logic in your app and set the `invalid` prop to display it as invalid.
 
-`error` is often paired with `helpText` to provide feedback to the user about the error.
+`invalid` is often paired with `helpText` to provide feedback to the user about the error.
 
 ```js
 <TextField label="Email" invalid helpText="Ugyldig e-post" />


### PR DESCRIPTION
`error` prop is deprecated so we should avoid mentioning it in the docs as default for validation.

<img width="726" alt="Screenshot 2023-08-11 at 14 29 12" src="https://github.com/warp-ds/tech-docs/assets/41303231/d3fc9336-d573-470e-94de-89864d3273bd">
