### PR TITLE
fix: set unocss version to 0.54.3 to avoid errors in @warp-ds/uno

### DIFF
--- a/docs/getting-started/developers/index.md
+++ b/docs/getting-started/developers/index.md
@@ -25,7 +25,7 @@ A guide on how to integrate your project with UnoCSS and Warp.
 `alpha` versions of @warp-ds packages should be installed until major versions are available. Below versions are compatible with the theme stylesheets mentioned in the [Apply Theme](#_2-apply-theme) section.
 
 ```shell
-npm install unocss @warp-ds/uno@1.0.0-alpha.49 @warp-ds/component-classes@1.0.0-alpha.116
+npm install unocss@0.54.3 @warp-ds/uno@1.0.0-alpha.49 @warp-ds/component-classes@1.0.0-alpha.116
 ```
 
 #### If you are using Webpack


### PR DESCRIPTION
When the latest unocss (0.55.0) is installed with `@warp-ds/uno@1.0.0-alpha.49`, an error is thrown:

``` 
import { escapeSelector, createValueHandler, isString, escapeRegExp, CountableSet, BetterMap } from '@unocss/core';
                                                                     ^^^^^^^^^^^^
SyntaxError: The requested module '@unocss/core' does not provide an export named 'CountableSet'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:128:21)
```
The above error is a result of `@warp-ds/uno` keeping a dependency of `@unocss/core` at a lower version, which seems to be incompatible with the newest unocss version.

Until we update `@warp-ds/uno` dependencies and release a new version of that package, we need to advise users to install a compatible version of `unocss`, which as far as I tested can be `0.54.3`.