### PR TITLE
fix(getting-started-dev): headings structure

### DIFF
--- a/docs/getting-started/developers/elements.md
+++ b/docs/getting-started/developers/elements.md
@@ -10,9 +10,16 @@ npm install @warp-ds/elements@1.0.0-alpha.27
 
 ## Using Components
 
-Once installed, components can be used in your HTML markup.
+Once installed, components can be imported into your app.
 
 ```js
+import '@warp-ds/elements';
+```
+> When importing from NPM you will need to ensure you have build tooling in place. If you are working with Podium podlets or layouts, you likely already have Eik in place with Rollup or Esbuild, in which case no further action should be needed.
+
+Then they can be used in your HTML markup.
+
+```html
 <f-breadcrumbs class="mt-10">
   <a href="#/url/1">Eiendom</a>
   <a href="#/url/2">Bolig til salgs</a>
@@ -20,11 +27,3 @@ Once installed, components can be used in your HTML markup.
 </f-breadcrumbs>
 ```
 
-### Importing from the NPM package
-👉 _**This is the most common method and should be used in most cases**_ 
-
-When importing from NPM you will need to ensure you have build tooling in place. If you are working with Podium podlets or layouts, you likely already have Eik in place with Rollup or Esbuild, in which case no further action should be needed.
-Example
-```
-import '@warp-ds/elements';
-```

--- a/docs/getting-started/developers/index.md
+++ b/docs/getting-started/developers/index.md
@@ -44,7 +44,9 @@ See [UnoCSS docs](https://unocss.dev/integrations/webpack) for more information.
 
 When setting up Warp in your project, you can choose to create an `uno.config` file, or you can include the UnoCSS configuration settings directly in the build tool. Below, the two different alternatives are described.
 
-- **Alternative 1: Add a uno.config file**
+##### Alternative 1
+
+- **Add a uno.config file**
 
 Create a `uno.config.[js,ts,mjs,mts]` file with the following content. This file will configure UnoCSS with our Warp preset, including a safelist of component classes, which will add styling to Warp components. See all configuration options for `presetWarp` in the [Warp CSS docs](https://warp-ds.github.io/css-docs/plugin-api).
 
@@ -63,7 +65,7 @@ export default defineConfig({
 
 By default, UnoCSS will automatically look in the root directory of your project for `uno.config.[js,ts,mjs,mts]` or `unocss.config.[js,ts,mjs,mts]`.
 
-#### Add UnoCSS to your build tool
+- **Add UnoCSS to your build tool**
 
 Then add UnoCSS to your build tool
 
@@ -78,7 +80,9 @@ export default defineConfig({
 });
 ```
 
-- **Alternative 2: Include UnoCSS directly in the build setup**
+##### **Alternative 2**
+
+- **Include UnoCSS directly in the build setup**
 
 You can also specify the configuration file manually and in that case you won't need a separate `uno.config` file.
 


### PR DESCRIPTION
### Changes included:
- Instruct to import Warp Elements before use in HTML markup - this bit was copied from [Fabric docs](https://elements.fabric-ds.io/) but it seems to be confusing to mention imports after usage
- Use h5 headings in the "Configuration and Setup" to improve readability of the content. This also improves the table of contents section:
![Screenshot 2023-08-16 at 08 56 24](https://github.com/warp-ds/tech-docs/assets/41303231/71faf242-6951-40e2-b0b9-58ad69ae8c8d)
