### PR TITLE
fix: add negative it is own button type

### DIFF
--- a/docs/api-table.js
+++ b/docs/api-table.js
@@ -822,8 +822,9 @@ export const vue = {
       ],
     ],
     variants: [
-      ['primary', 'negative, quiet, small, loading'],
+      ['primary', 'quiet, small, loading'],
       ['secondary', 'quiet, small, loading'],
+      ['negative', 'quiet, small, loading'],
       ['link', 'small'],
       ['utility', 'small, loading'],
       ['pill', ''],


### PR DESCRIPTION
`negative` is a button type and not a modifier anymore, in Vue that is. It is now aligned through the different implementations in all of our frameworks.

Changes were made: https://github.com/warp-ds/vue/pull/63 and https://github.com/warp-ds/vue/pull/62
