### PR TITLE
fix: Add missing border to api-table header

### DIFF
--- a/docs/.vitepress/ApiTable.vue
+++ b/docs/.vitepress/ApiTable.vue
@@ -71,7 +71,7 @@ const data = computed(() => apiTable[props.type || 'react'][props.component]);
     }
 
     thead {
-      border-bottom: 1px solid var(--vp-c-divider-light);
+      border-bottom: 1px solid var(--vp-c-divider);
 
       tr {
         text-transform: uppercase;


### PR DESCRIPTION
There was no css variable named --vp-c-divider-light