### PR TITLE
Add markdown components for showing links to Figma and Slack

### DIFF
--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -2,6 +2,8 @@ import DefaultTheme from 'vitepress/theme';
 import ApiTable from '../ApiTable.vue';
 import TabsContent from '../TabsContent.vue';
 import ThemeSwitcher from '../ThemeSwitcher.vue';
+import ComponentDesignGuidelines from '../../components/ComponentDesignGuidelines.md';
+import ComponentQuestions from '../../components/ComponentQuestions.md';
 import ComponentsStatus from '../ComponentsStatus.vue';
 import '../bootExamples.js';
 import './custom.css';
@@ -12,6 +14,8 @@ export default {
     app.component('ApiTable', ApiTable);
     app.component('ThemeSwitcher', ThemeSwitcher);
     app.component('TabsContent', TabsContent);
+    app.component('ComponentDesignGuidelines', ComponentDesignGuidelines);
+    app.component('ComponentQuestions', ComponentQuestions);
     app.component('ComponentsStatus', ComponentsStatus);
   },
 };

--- a/docs/components/ComponentDesignGuidelines.md
+++ b/docs/components/ComponentDesignGuidelines.md
@@ -1,0 +1,8 @@
+<script setup>
+const props = defineProps({
+  name: String,
+  link: String,
+});
+</script>
+### Design Guidelines
+See Figma: <a :href="link" target="_blank">{{ name }}</a>

--- a/docs/components/ComponentQuestions.md
+++ b/docs/components/ComponentQuestions.md
@@ -1,0 +1,2 @@
+### Questions?
+Feel free to ask any questions on usage in the Warp DS Slack channel: [#nmp-warp-design-system](https://sch-chat.slack.com/archives/C04P0GYTHPV)


### PR DESCRIPTION
Add markdown components for showing links to Figma and Slack in the component docs.
I will add this to each component in a coming PR.