### PR TITLE
Misc fixes for component docs

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -11,7 +11,7 @@ const docsClasses = ['text-12', 'font-bold', 'space-y-24', 'space-x-24','mt-16',
 'top-12','left-12','bg-aqua-200','text-aqua-900','p-4','rounded-4','p-16','font-bold','my-8', 'gap-10', 'w-100',
 'max-w-screen-xl', 'mx-auto', 'px-32', 's-bg-active', 'rounded-8', 'p-24', 'mb-24', 'grid', 'gap-24', 'mx-auto', 'mb-8',
 's-bg', 'rounded-4', 'h-56', 'flex', 'items-center', 'justify-center', 'flex-col', 's-icon', 'grid-cols-minmax-100px',
-];
+'last:ml-auto!',];
 
 export default defineConfig({
   lang: 'en-US',

--- a/docs/components/ComponentDesignGuidelines.md
+++ b/docs/components/ComponentDesignGuidelines.md
@@ -2,7 +2,12 @@
 const props = defineProps({
   name: String,
   link: String,
+  links: Array
 });
 </script>
 ### Design Guidelines
-See Figma: <a :href="link" target="_blank">{{ name }}</a>
+
+<p>
+  See Figma: <a v-if="link" :href="link" target="_blank">{{ name }}</a>
+  <span v-else v-for="item in links" :key="item.name"><br /><a :href="item.link" target="_blank">{{ item.name }}</a></span>
+</p>

--- a/docs/components/alert/Example.vue
+++ b/docs/components/alert/Example.vue
@@ -6,28 +6,30 @@
 </script>
 
 <template>
-  <h3>Info</h3>
-  <div class="component">
-    <w-alert v-model="showAlert" info title="This is the info variant of the alert element">
-      <p>I am an excellent message for the user.</p>
-    </w-alert>
-  </div>
-  <h3>Positive</h3>
-  <div class="component">
-    <w-alert v-model="showAlert" positive title="This is the positive variant of the alert element">
-      <p>With an additional description</p>
-    </w-alert>
-  </div>
-  <h3>Negative</h3>
-  <div class="component">
-    <w-alert v-model="showAlert" negative title="This is the negative variant of the alert element">
-      <p>With an additional description</p>
-    </w-alert>
-  </div>
-  <h3>Warning</h3>
-  <div class="component">
-    <w-alert v-model="showAlert" warning title="This is the warning variant of the alert element">
-      <p>With an additional description</p>
-    </w-alert>
+  <div class="component space-y-16">
+    <div>
+      <h3 class="h4">Info</h3>
+      <w-alert v-model="showAlert" info title="This is the info variant of the alert element">
+        <p>I am an excellent message for the user.</p>
+      </w-alert>
+    </div>
+    <div>
+      <h3 class="h4">Positive</h3>
+      <w-alert v-model="showAlert" positive title="This is the positive variant of the alert element">
+        <p>With an additional description</p>
+      </w-alert>
+    </div>
+    <div>
+      <h3 class="h4">Negative</h3>
+      <w-alert v-model="showAlert" negative title="This is the negative variant of the alert element">
+        <p>With an additional description</p>
+      </w-alert>
+    </div>
+    <div>
+      <h3 class="h4">Warning</h3>
+      <w-alert v-model="showAlert" warning title="This is the warning variant of the alert element">
+        <p>With an additional description</p>
+      </w-alert>
+    </div>
   </div>
 </template>

--- a/docs/components/alert/elements.md
+++ b/docs/components/alert/elements.md
@@ -1,13 +1,13 @@
-## Syntax
+### Syntax
 
-```js
+```html
 <w-alert variant="info" show="">
   <p class="font-bold">This is "info" variant of the alert element</p>
   <p>With an additional description</p>
 </w-alert>
 ```
 
-## Accessibility
+### Accessibility
 
 Use the ARIA live region `role` attribute to provide meaning to the alert
 element (defaults to "alert"). If you want to remove the role from the alert and
@@ -17,18 +17,18 @@ property of the `Alert` component to an empty string and assigning a respective
 attribute on
 [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#roles_with_implicit_live_region_attributes).
 
-### Alert with "alert" role on a descendand element
+#### Alert with "alert" role on a descendant element
 
-```js
-<Alert type="info" show={show} role="">
-  <p role="alert" className="font-bold">
+```html
+<w-alert type="info" show={show} role="">
+  <p role="alert" class="font-bold">
     This is "info" variant of the alert element
   </p>
   <p>With an additional description</p>
   <a>And a link to more information</a>
-</Alert>
+</w-alert>
 ```
 
-## Props
+### Props
 
 <api-table type=elements component="Alert" />

--- a/docs/components/alert/index.md
+++ b/docs/components/alert/index.md
@@ -16,6 +16,12 @@ Alert is an inline component used for displaying different types of messages.
 
 <alert-example></alert-example>
 
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
+
 ## Frameworks
 
 <tabs-content> 

--- a/docs/components/alert/index.md
+++ b/docs/components/alert/index.md
@@ -14,7 +14,7 @@ Alert is an inline component used for displaying different types of messages.
 
 <theme-switcher />
 
-<alert-example></alert-example>
+<alert-example />
 
 ## Usage
 

--- a/docs/components/alert/react.md
+++ b/docs/components/alert/react.md
@@ -1,10 +1,10 @@
-## Import
+### Import
 
 ```js
 import { Alert } from "@warp-ds/react";
 ```
 
-## Syntax
+### Syntax
 
 ```js
 <Alert type="info" show>
@@ -12,7 +12,7 @@ import { Alert } from "@warp-ds/react";
 </Alert>
 ```
 
-## Accessibility
+### Accessibility
 
 Use the ARIA live region `role` attribute to provide meaning to the alert
 element (defaults to "alert"). If you want to remove the role from the alert and
@@ -22,7 +22,7 @@ property of the `Alert` component to an empty string and assigning a respective
 attribute on
 [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#roles_with_implicit_live_region_attributes).
 
-### Alert with "alert" role on a descendand element
+#### Alert with "alert" role on a descendant element
 
 ```js
 <Alert type="info" show={show} role="">
@@ -34,6 +34,6 @@ attribute on
 </Alert>
 ```
 
-## Props
+### Props
 
 <api-table type=react component="Alert" />

--- a/docs/components/alert/vue.md
+++ b/docs/components/alert/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 
@@ -13,14 +13,14 @@ app.use(Alert);
 import { wAlert } from "@warp-ds/vue";
 ```
 
-## Syntax
+### Syntax
 
-```js
+```vue
 <w-alert v-model="showAlert" info title="I am a title">
   <p>I am an excellent message for the user.</p>
 </w-alert>
 ```
 
-## Props
+### Props
 
 <api-table type=vue component="Alert" />

--- a/docs/components/attention/Example.vue
+++ b/docs/components/attention/Example.vue
@@ -12,25 +12,29 @@ const popoverShowing = ref(false)
 </script>
 
 <template>
-  <h2>Callout</h2>
-  <div class="component flex items-center">
-    <w-box neutral class="h4" ref="calloutTarget" @mouseenter="calloutShowing = true; target = $refs.calloutTarget" @mouseleave="calloutShowing = false">Hover over me</w-box>
-    <w-attention callout right :target-el="calloutTarget ? calloutTarget.$el : null" v-model="calloutShowing" class="ml-8">
-      <p>This is a callout</p>
-    </w-attention>
-  </div>
-  <h2>Tooltip</h2>
-  <div class="component">
-    <w-box neutral class="h4" ref="tooltipTarget" @mouseenter="tooltipShowing = true; target = $refs.tooltipTarget" @mouseleave="tooltipShowing = false">Hover over me</w-box>
-    <w-attention tooltip bottom :target-el="tooltipTarget ? tooltipTarget.$el : null" v-model="tooltipShowing">
-      <p>This is a tooltip</p>
-    </w-attention>
-  </div>
-  <h2>Popover</h2>
-  <div class="component">
-    <w-box neutral class="h4" ref="popoverTarget" @mouseenter="popoverShowing = true; target = $refs.popoverTarget" @mouseleave="popoverShowing = false">Hover over me</w-box>
-    <w-attention popover bottom :target-el="popoverTarget ? popoverTarget.$el : null" v-model="popoverShowing">
-      <p>This is a popover</p>
-    </w-attention>
+  <div class="component space-y-16">
+    <div>
+      <h3 class="h4">Callout</h3>
+      <div class="flex items-center">
+        <w-box neutral ref="calloutTarget" @mouseenter="calloutShowing = true; target = $refs.calloutTarget" @mouseleave="calloutShowing = false">Hover over me</w-box>
+        <w-attention callout right :target-el="calloutTarget ? calloutTarget.$el : null" v-model="calloutShowing" class="ml-8">
+          <p>This is a callout</p>
+        </w-attention>
+      </div>
+    </div>
+    <div>
+      <h3 class="h4">Tooltip</h3>
+      <w-box neutral ref="tooltipTarget" @mouseenter="tooltipShowing = true; target = $refs.tooltipTarget" @mouseleave="tooltipShowing = false">Hover over me</w-box>
+      <w-attention tooltip bottom :target-el="tooltipTarget ? tooltipTarget.$el : null" v-model="tooltipShowing">
+        <p>This is a tooltip</p>
+      </w-attention>
+    </div>
+    <div>
+      <h3 class="h4">Popover</h3>
+      <w-box neutral ref="popoverTarget" @mouseenter="popoverShowing = true; target = $refs.popoverTarget" @mouseleave="popoverShowing = false">Hover over me</w-box>
+      <w-attention popover bottom :target-el="popoverTarget ? popoverTarget.$el : null" v-model="popoverShowing">
+        <p>This is a popover</p>
+      </w-attention>
+    </div>
   </div>
 </template>

--- a/docs/components/attention/elements.md
+++ b/docs/components/attention/elements.md
@@ -1,6 +1,6 @@
-## Visual options
+### Visual options
 
-### Popover
+#### Popover
 
 ```js
 <w-attention placement="bottom" popover="">
@@ -11,7 +11,7 @@
 </w-attention>
 ```
 
-### Callout
+#### Callout
 
 ```js
 <w-attention placement="right" show="" callout="" class="flex items-center">
@@ -22,7 +22,7 @@
 </w-attention>
 ```
 
-### Tooltip
+#### Tooltip
 
 ```js
 <w-attention placement="right" tooltip="">
@@ -33,7 +33,7 @@
 </w-attention>
 ```
 
-## Accessibility
+### Accessibility
 If the Attention element has "left" or "top" position, it should be placed before the target element in the DOM.
 
 Attention element handles accessibility automatically by wrapping its slotted content with a `div` with `role="tooltip"`, and setting an aria-describedby attribute on the target element.
@@ -52,6 +52,6 @@ It is possible to tell assistive technologies to recognize only a part of Attent
 </w-attention>
 ```
 
-## Props
+### Props
 
 <api-table type="elements" component="Attention" />

--- a/docs/components/attention/index.md
+++ b/docs/components/attention/index.md
@@ -16,15 +16,18 @@
 
 ## Usage
 
-<component-design-guidelines name="Warp - Components / Callout" link="https://www.figma.com/file/nkiRpuVu6XRfvY96BA80H8/Components-overview?type=design&node-id=259-13731&mode=design" />
-
+<component-design-guidelines :links="[
+{ name: 'Warp - Components / Callout', link:'https://www.figma.com/file/nkiRpuVu6XRfvY96BA80H8/Components-overview?type=design&node-id=259-13731&mode=design' },
+{ name: 'Warp - Components / Tooltip', link:'https://www.figma.com/file/nkiRpuVu6XRfvY96BA80H8/Components-overview?type=design&node-id=377-23911&mode=design' },
+{ name: 'Warp - Components / Popover', link:'https://www.figma.com/file/nkiRpuVu6XRfvY96BA80H8/Components-overview?type=design&node-id=374-22825&mode=design' },
+]" />
 <component-questions />
 
 ## Frameworks
 
 <tabs-content>
   <template #react>
-   <react />
+    <react />
   </template>
   <template #vue>
     <vue />

--- a/docs/components/attention/index.md
+++ b/docs/components/attention/index.md
@@ -12,7 +12,13 @@
 
 <theme-switcher />
 
-<attention-example></attention-example>
+<attention-example />
+
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
 
 ## Frameworks
 

--- a/docs/components/attention/react.md
+++ b/docs/components/attention/react.md
@@ -1,12 +1,12 @@
-## Import
+### Import
 
 ```js
 import { Attention } from '@warp-ds/react';
 ```
 
-## Visual options
+### Visual options
 
-### Callout
+#### Callout
 
 ```js
 <div>
@@ -19,7 +19,7 @@ import { Attention } from '@warp-ds/react';
 </div>
 ```
 
-### Tooltip
+#### Tooltip
 
 ```js
 function Example() {
@@ -48,7 +48,7 @@ function Example() {
 }
 ```
 
-### Popover
+#### Popover
 
 ```js
 function Example() {
@@ -98,6 +98,6 @@ function Example() {
 }
 ```
 
-## Props
+### Props
 
 <api-table type="react" component="Attention" />

--- a/docs/components/attention/vue.md
+++ b/docs/components/attention/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 
@@ -13,11 +13,11 @@ app.use(Attention);
 import { wAttention } from '@warp-ds/vue';
 ```
 
-## Visual options
+### Visual options
 
-### Callout
+#### Callout
 
-```js
+```vue
 <script>
 import { ref } from 'vue'
 import { wAttention, wBox } from '#components'
@@ -33,9 +33,9 @@ const showing = ref(false)
 </template>
 ```
 
-### Popover
+#### Popover
 
-```js
+```vue
 <script>
 import { ref } from 'vue'
 import { wAttention, wBox } from '#components'
@@ -51,9 +51,9 @@ const showing = ref(false)
 </template>
 ```
 
-### Tooltip
+#### Tooltip
 
-```js
+```vue
 <script>
 import { ref } from 'vue'
 import { wAttention, wBox } from '#components'
@@ -69,6 +69,6 @@ const showing = ref(false)
 </template>
 ```
 
-## Props
+### Props
 
 <api-table type="vue" component="Attention" />

--- a/docs/components/box/Example.vue
+++ b/docs/components/box/Example.vue
@@ -3,24 +3,24 @@
 </script>
 
 <template>
-  <h3>Neutral</h3>
-  <div class="component">
-    <w-box neutral>
-      <p>This is the <strong>neutral</strong> variant of the box element</p>
-    </w-box>
-  </div>
-
-  <h3>Info</h3>
-  <div class="component">
-    <w-box info>
-      <p>This is the <strong>info</strong> variant of the box element</p>
-    </w-box>
-  </div>
-
-  <h3>Bordered</h3>
-  <div class="component">
-    <w-box bordered>
-      <p>This is the <strong>bordered</strong> variant of the box element</p>
-    </w-box>
+  <div class="component space-y-16">
+    <div>
+      <h3 class="h4">Neutral</h3>
+      <w-box neutral>
+        <p>This is the <strong>neutral</strong> variant of the box element</p>
+      </w-box>
+    </div>
+    <div>
+      <h3 class="h4">Info</h3>
+      <w-box info>
+        <p>This is the <strong>info</strong> variant of the box element</p>
+      </w-box>
+    </div>
+    <div>
+      <h3 class="h4">Bordered</h3>
+      <w-box bordered>
+        <p>This is the <strong>bordered</strong> variant of the box element</p>
+      </w-box>
+    </div>
   </div>
 </template>

--- a/docs/components/box/elements.md
+++ b/docs/components/box/elements.md
@@ -2,7 +2,7 @@
 
 ```js
 <w-box info>
-    <p>This is "info" variant of the box component</p>
+    <p>This is <strong>info</strong> variant of the box component</p>
 </w-box>
 ```
 

--- a/docs/components/box/elements.md
+++ b/docs/components/box/elements.md
@@ -1,12 +1,11 @@
-## Syntax
+### Syntax
 
 ```js
 <w-box info>
-    <h1>Default example</h1>
     <p>This is "info" variant of the box component</p>
 </w-box>
 ```
 
-## Props
+### Props
 
 <api-table type=elements component="Box" />

--- a/docs/components/box/index.md
+++ b/docs/components/box/index.md
@@ -16,6 +16,12 @@ Box is a layout component used for separating content areas on a page.
 
 <box-example />
 
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
+
 ## Frameworks
 
 <tabs-content> 

--- a/docs/components/box/react.md
+++ b/docs/components/box/react.md
@@ -8,7 +8,7 @@ import { Box } from "@warp-ds/react";
 
 ```js
 <Box info>
-    <p>This is "info" variant of the box component</p>
+    <p>This is <strong>info</strong> variant of the box component</p>
 </Box>
 ```
 

--- a/docs/components/box/react.md
+++ b/docs/components/box/react.md
@@ -1,18 +1,17 @@
-## Import
+### Import
 
 ```js
 import { Box } from "@warp-ds/react";
 ```
 
-## Syntax
+### Syntax
 
 ```js
 <Box info>
-    <h1>Default example</h1>
     <p>This is "info" variant of the box component</p>
 </Box>
 ```
 
-## Props
+### Props
 
 <api-table type="react" component="Box" />

--- a/docs/components/box/vue.md
+++ b/docs/components/box/vue.md
@@ -17,7 +17,7 @@ import { wBox } from "@warp-ds/vue";
 
 ```vue
 <w-box info>
-    <p>This is "info" variant of the box component</p>
+    <p>This is <strong>info</strong> variant of the box component</p>
 </w-box>
 ```
 

--- a/docs/components/box/vue.md
+++ b/docs/components/box/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 
@@ -13,15 +13,14 @@ app.use(Box);
 import { wBox } from "@warp-ds/vue";
 ```
 
-## Syntax
+### Syntax
 
-```js
+```vue
 <w-box info>
-    <h1>Default example</h1>
     <p>This is "info" variant of the box component</p>
 </w-box>
 ```
 
-## Props
+### Props
 
 <api-table type=vue component="Box" />

--- a/docs/components/breadcrumbs/elements.md
+++ b/docs/components/breadcrumbs/elements.md
@@ -1,6 +1,6 @@
-## Syntax
+### Syntax
 
-```js
+```html
 <w-breadcrumbs>
   <a href="#/url/1">Page 1</a>
   <a href="#/url/2">Page 2</a>
@@ -8,6 +8,6 @@
 </w-breadcrumbs>
 ```
 
-## Props
+### Props
 
 <api-table type="elements" component="Breadcrumbs" />

--- a/docs/components/breadcrumbs/index.md
+++ b/docs/components/breadcrumbs/index.md
@@ -17,20 +17,23 @@ Breadcrumbs show the navigation structure for the current location.
 <breadcrumbs-example />
 
 ## Usage
-### Content
 
+### Content
 Breadcrumbs expect their component children to be the link "crumbs" that make up
 the navigation structure. The component will interject a separator between the
 crumbs.
 
-### Accessibility
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
 
+### Accessibility
 Breadcrumbs should have a label that identifies the structure as a breadcrumb
 trail to screen readers. Until internationalization is added to Warp components, by default `aria-label` is set to <em>"Her er du"</em> (Norwegian).
 
 It is recommended that the crumb for the current page has the
 `aria-current="page"` attribute set. Usually this is the last crumb in the
 trail.
+
+<component-questions />
 
 ## Frameworks
 

--- a/docs/components/breadcrumbs/react.md
+++ b/docs/components/breadcrumbs/react.md
@@ -1,10 +1,10 @@
-## Import
+### Import
 
 ```js
 import { Breadcrumbs } from '@warp-ds/react';
 ```
 
-## Syntax
+### Syntax
 
 ```js
 <Breadcrumbs>
@@ -16,7 +16,7 @@ import { Breadcrumbs } from '@warp-ds/react';
 </Breadcrumbs>
 ```
 
-## Props
+### Props
 
 <api-table type="react" component="Breadcrumbs" />
 

--- a/docs/components/breadcrumbs/vue.md
+++ b/docs/components/breadcrumbs/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 
@@ -13,9 +13,9 @@ app.use(Breadcrumbs);
 import { wBreadcrumbs } from "@warp-ds/vue";
 ```
 
-## Syntax
+### Syntax
 
-```js
+```vue
 <w-breadcrumbs>
   <a href="#/url/1">Page 1</a>
   <a href="#/url/2">Page 2</a>
@@ -23,6 +23,6 @@ import { wBreadcrumbs } from "@warp-ds/vue";
 </w-breadcrumbs>
 ```
 
-## Props
+### Props
 
 <api-table type="vue" component="Breadcrumbs" />

--- a/docs/components/broadcast/elements.md
+++ b/docs/components/broadcast/elements.md
@@ -1,12 +1,12 @@
-## Syntax
+### Syntax
 
-```js
+```html
 <w-broadcast 
   api="https://dev.finn.no/broadcasts"
   url="https:/dev.finn.no/meldinger" interval="30000">
 </w-broadcast>
 ```
 
-## Props
+### Props
 
 <api-table type="elements" component="Broadcast" />

--- a/docs/components/broadcast/index.md
+++ b/docs/components/broadcast/index.md
@@ -16,13 +16,15 @@ Uses toast apis under the hood.
 
 See the [toast component](/components/toast/) for examples, as `broadcast` utilizes it to display messages.
 
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
+
 ## Frameworks
 
 <tabs-content>
-  <template #react>
-  </template>
-  <template #vue>
-  </template>
   <template #elements>
     <elements />
   </template>

--- a/docs/components/buttongroup/Example.vue
+++ b/docs/components/buttongroup/Example.vue
@@ -1,50 +1,46 @@
 <script setup>
-import { ref, reactive } from 'vue'
+import { ref, reactive } from 'vue';
 import { wButtonGroup, wButtonGroupItem, wClickable } from '@warp-ds/vue';
 
-const checkbox = true
-const radio = true
-const useIsActive = (state) => (name) => state.active === name
-const buildCheckboxState = ({ controls, active }) => controls.reduce((acc, e) => (acc[e.name] = e.name === active, acc), {})
+const checkbox = true;
+const radio = true;
+const useIsActive = (state) => (name) => state.active === name;
+const buildCheckboxState = ({ controls, active }) => controls.reduce((acc, e) => (acc[e.name] = e.name === active, acc), {});
 
-const radioModel = ref('foo')
-const alert = () => window.alert('Hello Warp!')
+const radioModel = ref('foo');
+const alert = () => window.alert('Hello Warp!');
 
-const type = reactive({ active: 'Radio' })
-const active = useIsActive(type)
+const type = reactive({ active: 'Radio' });
+const active = useIsActive(type);
 const typeControls = [
   { name: 'Radio', radio },
   { name: 'Button', radio },
-]
+];
 
 const modifierControls = [
   { name: 'Outlined', checkbox },
   { name: 'Raised', checkbox },
   { name: 'Vertical', checkbox },
-]
-const modifiers = reactive(buildCheckboxState({ controls: modifierControls }))
+];
+const modifiers = reactive(buildCheckboxState({ controls: modifierControls }));
 </script>
 
 <template>
   <div class="component">
-    <component-title title="Button Group" />
-
-    <token :state="[type, radioModel, modifiers]">
-      <w-button-group :outlined="modifiers.Outlined" :raised="modifiers.Raised" :vertical="modifiers.Vertical" class="mb-32">
-        <w-button-group-item :selected="active('Radio') && radioModel === 'foo'">
-          <w-clickable v-if="active('Radio')" label radio v-model="radioModel" value="foo">Foo</w-clickable>
-          <w-clickable v-else label @click="alert">Foo</w-clickable>
-        </w-button-group-item>
-        <w-button-group-item :selected="active('Radio') && radioModel === 'bar'">
-          <w-clickable v-if="active('Radio')" label radio v-model="radioModel" value="bar">Bar</w-clickable>
-          <w-clickable v-else label @click="alert">Bar</w-clickable>
-        </w-button-group-item>
-        <w-button-group-item :selected="active('Radio') && radioModel === 'baz'">
-          <w-clickable v-if="active('Radio')" label radio v-model="radioModel" value="baz">Baz</w-clickable>
-          <w-clickable v-else label @click="alert">Baz</w-clickable>
-        </w-button-group-item>
-      </w-button-group>
-    </token>
+    <w-button-group :outlined="modifiers.Outlined" :raised="modifiers.Raised" :vertical="modifiers.Vertical" class="mb-32">
+      <w-button-group-item :selected="active('Radio') && radioModel === 'foo'">
+        <w-clickable v-if="active('Radio')" label radio v-model="radioModel" value="foo">Foo</w-clickable>
+        <w-clickable v-else label @click="alert">Foo</w-clickable>
+      </w-button-group-item>
+      <w-button-group-item :selected="active('Radio') && radioModel === 'bar'">
+        <w-clickable v-if="active('Radio')" label radio v-model="radioModel" value="bar">Bar</w-clickable>
+        <w-clickable v-else label @click="alert">Bar</w-clickable>
+      </w-button-group-item>
+      <w-button-group-item :selected="active('Radio') && radioModel === 'baz'">
+        <w-clickable v-if="active('Radio')" label radio v-model="radioModel" value="baz">Baz</w-clickable>
+        <w-clickable v-else label @click="alert">Baz</w-clickable>
+      </w-button-group-item>
+    </w-button-group>
 
     <demo-controls y>
       <demo-control label="Type" :controls="typeControls" :state="type" />

--- a/docs/components/buttongroup/index.md
+++ b/docs/components/buttongroup/index.md
@@ -19,8 +19,6 @@ Button Group is used to group and align clickable elements, applying different v
 This component is only supported in Warp Vue at the moment.
 For a React equivalent that serves a similar purpose, use the `Toggle` in [RadioButtons](/components/radiobuttons/).
 
-<component-design-guidelines name="Warp - Components / Button Group" link="https://www.figma.com/file/nkiRpuVu6XRfvY96BA80H8/Components-overview?type=design&node-id=384-34744&mode=design" />
-
 <component-questions />
 
 ## Frameworks

--- a/docs/components/buttongroup/index.md
+++ b/docs/components/buttongroup/index.md
@@ -7,6 +7,7 @@
 Button Group is used to group and align clickable elements, applying different visuals for different needs.
 
 <components-status vue='released' />
+
 ## Example
 
 <theme-switcher />
@@ -14,18 +15,18 @@ Button Group is used to group and align clickable elements, applying different v
 <buttongroup-example />
 
 ## Usage
-This component is only supported in Warp Vue at the moment.
 
+This component is only supported in Warp Vue at the moment.
 For a React equivalent that serves a similar purpose, use the `Toggle` in [RadioButtons](/components/radiobuttons/).
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
 
 ## Frameworks
 
 <tabs-content> 
-  <template #react>
-  </template>
   <template #vue>
     <vue />
-  </template>
-  <template #elements>
   </template>
 </tabs-content>

--- a/docs/components/buttongroup/vue.md
+++ b/docs/components/buttongroup/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 
@@ -13,9 +13,9 @@ app.use(ButtonGroup);
 import { wButtonGroup, wButtonGroupItem } from "@warp-ds/vue";
 ```
 
-## Syntax
+### Syntax
 
-```js
+```vue
   <w-button-group>
     <w-button-group-item :selected="props.selected">
       <w-clickable label radio v-model="radioModel" value="foo">Foo</w-clickable>
@@ -29,13 +29,13 @@ import { wButtonGroup, wButtonGroupItem } from "@warp-ds/vue";
   </w-button-group>
 ```
 
-## Props
+### Props
 
-### ButtonGroup props
+#### ButtonGroup props
 
 <api-table type="vue" component="ButtonGroup" />
 
-### ButtonGroupItem props
+#### ButtonGroupItem props
 
 <api-table type="vue" component="ButtonGroupItem" />
 

--- a/docs/components/buttons/Example.vue
+++ b/docs/components/buttons/Example.vue
@@ -1,15 +1,15 @@
 <script setup>
-    import { wButton } from '@warp-ds/vue';
+  import { wButton } from '@warp-ds/vue';
 </script>
 
 <template>
-    <div class="space-x-8 space-y-16 text-center">
-        <w-button primary>Primary</w-button>
-        <w-button primary loading>Loading</w-button>
-        <w-button utility>Utility</w-button>
-        <w-button>Secondary</w-button>
-        <w-button secondary quiet>Secondary Quiet</w-button>
-        <w-button primary negative>Negative</w-button>
-        <w-button negative quiet>Negative Quiet</w-button>
-    </div>
+  <div class="component space-x-8 space-y-16 text-center">
+    <w-button primary>Primary</w-button>
+    <w-button primary loading>Loading</w-button>
+    <w-button utility>Utility</w-button>
+    <w-button>Secondary</w-button>
+    <w-button secondary quiet>Secondary Quiet</w-button>
+    <w-button primary negative>Negative</w-button>
+    <w-button negative quiet>Negative Quiet</w-button>
+  </div>
 </template>

--- a/docs/components/buttons/elements.md
+++ b/docs/components/buttons/elements.md
@@ -1,80 +1,81 @@
-## Syntax
+### Syntax
 
-```js
+```html
 <w-button variant="primary">Primary button</w-button>
 ```
 
-## Variants
+### Variants
 
-### Primary
+#### Primary
 The primary button is a call to action. Can be combined with "small" attribute.
 
-```js
+```html
 <w-button variant="primary">Primary button</w-button>
 <w-button variant="primary" small>Primary button small</w-button>
 ```
 
-### Secondary
+#### Secondary
 The secondary button is for secondary or tertiary actions. Can be combined with "small" and "quiet" attributes. "secondary" is the default value of the "variant" attribute.
 
-```js
+```html
 <w-button variant="secondary">Secondary button</w-button>
 <w-button variant="secondary" small>Secondary button small</w-button>
 ```
 
-### Negative
+#### Negative
 The negative button is for emphasizing actions that can be destructive or have negative consequences if taken. Can be combined with "small" and "quiet" attributes.
 
-```js
+```html
 <w-button variant="negative">Negative button</w-button>
 <w-button variant="negative" small>Negative button small</w-button>
 ```
 
-### Utility
+#### Utility
 
-```js
+```html
 <w-button variant="utility">Utility button</w-button>
 <w-button variant="utility" small>Utility button small</w-button>
 ```
 
-### Link
+#### Link
 
-```js
+```html
 <w-button variant="link">Link button</w-button>
 <w-button variant="link" small>Link button small</w-button>
 ```
 
-### Pill
+#### Pill
 
-```js
+```html
 <w-button variant="pill">💙</w-button>
 <w-button variant="pill" small>💙</w-button>
 ```
 
-## Quiet
+### Quiet
 By default, buttons have a visible stroke and fill. Quiet buttons do not have this visible stroke or fill and should only be used for secondary actions within a button group. Quiet buttons have the same padding rules as other action buttons and reveal a button-like background color when hovered.
-```js
+```html
 <w-button quiet="">Quiet secondary button</w-button>
 <w-button quiet="" variant="negative">Quiet negative button</w-button>
 <w-button quiet="" variant="utility">Quiet utility button</w-button>
 ```
 
-## Link
+### Link
 Buttons will be rendered as an anchor (a tag) if they use an href attribute.
-```js
+```html
 <w-button href="https://google.no">Button as anchor</w-button>
 ```
 
-## Loading state
+### Loading state
 To show the user that the action they triggered has begun, buttons have an in progress or loading state.
-```js
+```html
 <w-button variant="primary" loading="">Primary button loading</w-button>
 ```
 
-## Disabled state
+### Disabled state
 
-Disabled is an anti-pattern and is not supported. There will ALWAYS be users who don't understand why an element is disabled, or users who can't even see that it is disabled because of poor lighting conditions or other reasons.
+Disabled is an anti-pattern and is not supported.
+There will ALWAYS be users who don't understand why an element is disabled, or users who can't even see that it is disabled because of poor lighting conditions or other reasons.
 
-## Props
+### Props
 
 <api-table type=elements component="Button" />

--- a/docs/components/buttons/elements.md
+++ b/docs/components/buttons/elements.md
@@ -82,7 +82,7 @@ The fullWidth prop sets the button's width to its parent's width.
 #### Disabled state
 
 Disabled is an anti-pattern and is not supported.
-There will ALWAYS be users who don't understand why an element is disabled, or users who can't even see that it is disabled because of poor lighting conditions or other reasons.
+There will always be users who don't understand why an element is disabled, or users who can't even see that it is disabled because of poor lighting conditions or other reasons.
 
 ### Props
 

--- a/docs/components/buttons/index.md
+++ b/docs/components/buttons/index.md
@@ -17,16 +17,19 @@ Buttons are used to perform actions, with different visuals for different needs.
 
 ## Usage
 
-### Accessibility
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
 
+### Accessibility
 If the button doesn't have visible text content, such as when used with only an
 icon, an `aria-label` prop must be provided for accessibility.
+
+<component-questions />
 
 ## Frameworks
 
 <tabs-content> 
   <template #react>
-   <react />
+    <react />
   </template>
   <template #vue>
     <vue />

--- a/docs/components/buttons/react.md
+++ b/docs/components/buttons/react.md
@@ -1,18 +1,18 @@
-## Import
+### Import
 
 ```js
 import { Button } from '@warp-ds/react';
 ```
 
-## Syntax
+### Syntax
 
 ```jsx example
 <Button>Save</Button>
 ```
 
-## Visual options
+### Visual options
 
-### Primary
+#### Primary
 
 The primary button is a call to action. As a general rule, there should only be
 one of them on the screen. This guides the user towards the happy path.
@@ -21,7 +21,7 @@ one of them on the screen. This guides the user towards the happy path.
 <Button primary>Save</Button>
 ```
 
-### Negative
+#### Negative
 
 Used for destructive actions, like deletion. Shouldn't be used on the same
 screen as a primary button.
@@ -30,9 +30,10 @@ screen as a primary button.
 <Button negative>Delete</Button>
 ```
 
-### Secondary
+#### Secondary
 
-Secondary buttons are without background, and are often used for secondary actions. This is the default so you may simply omit the secondary property unless you want to use it with `quiet` variation.
+Secondary buttons are without background, and are often used for secondary actions.
+This is the default, so you may simply omit the secondary property unless you want to use it with `quiet` variation.
 
 ```jsx example
 <div className="flex space-x-32">
@@ -41,7 +42,7 @@ Secondary buttons are without background, and are often used for secondary actio
 </div>
 ```
 
-### Loading/In progress
+#### Loading/In progress
 
 Used for visual feedback that the action the user triggered is loading.
 
@@ -49,19 +50,19 @@ Used for visual feedback that the action the user triggered is loading.
 <Button loading>Save</Button>
 ```
 
-### Small
+#### Small
 
 ```jsx example
 <Button small>Small</Button>
 ```
 
-### Pill
+#### Pill
 
 ```jsx example
 <Button pill>Pill</Button>
 ```
 
-### Link
+#### Link
 
 Buttons will be rendered as an anchor (a tag) if they use an `href` attribute.
 
@@ -75,13 +76,13 @@ But if you need a button to look like a link, use the `link` property.
 <Button link>Link</Button>
 ```
 
-### Disabled
+#### Disabled
 
 Disabled is an anti-pattern and is not supported. There will ALWAYS be users who
 don't understand why an element is disabled, or users who can't even see that it
 is disabled because of poor lighting conditions or other reasons.
 
 
-### Props
+#### Props
 
 <api-table type=react component="Button" />

--- a/docs/components/buttons/react.md
+++ b/docs/components/buttons/react.md
@@ -78,7 +78,7 @@ But if you need a button to look like a link, use the `link` property.
 
 #### Disabled
 
-Disabled is an anti-pattern and is not supported. There will ALWAYS be users who
+Disabled is an anti-pattern and is not supported. There will always be users who
 don't understand why an element is disabled, or users who can't even see that it
 is disabled because of poor lighting conditions or other reasons.
 

--- a/docs/components/buttons/vue.md
+++ b/docs/components/buttons/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 
@@ -13,13 +13,13 @@ app.use(Button);
 import { wButton } from "@warp-ds/vue";
 ```
 
-## Syntax
+### Syntax
 
-```js
+```html
 <w-button primary>Click me</w-button>
 <w-button>Click me</w-button>
 ```
 
-## Props
+### Props
 
 <api-table type=vue component="Button" />

--- a/docs/components/card/Example.vue
+++ b/docs/components/card/Example.vue
@@ -11,8 +11,10 @@
 </script>
 
 <template>
-  <h3>Default</h3>
-  <div class="component flex gap-10">
+  <div class="component space-y-16">
+    <div>
+      <h3 class="h4">Default</h3>
+      <div class="flex gap-10">
         <w-card :selected="selected">
           <img class="h-128 w-full object-cover" src="https://source.unsplash.com/random/400x400" />
           <p class="absolute top-12 left-12 bg-aqua-200 text-aqua-900 p-4 rounded-4 text-12">Ukens bolig</p>
@@ -45,20 +47,19 @@
             <p class="font-bold my-8">52 m<span style="font-size: 10px; vertical-align: super;">2</span> Totalpris: 4 869 039 kr</p>
             <p class="text-14  mb-0">Eier (Selveier) <span class="">•</span> Leilighet <span class="">•</span> 2 soverom</p>
           </div>
-        
         </w-card>
       </div>
-      <h3>Toggles in cards</h3>
-      <div class="component">
-      
+    </div>
+    <div>
+      <h3 class="h4">Toggles in cards</h3>
       <w-card :selected="checkModel" class="w-max mb-8">
         <div class="p-24 flex">
           <w-dead-toggle checkbox v-model="checkModel" :value="true" />
           <w-clickable checkbox :value="true" v-model="checkModel" label-class="ml-12 text-16">Check in a card</w-clickable>
         </div>
       </w-card>
-
-        <w-card :selected="radioModel === 'foo'" class="w-max mb-8">
+      <div class="flex gap-10">
+        <w-card :selected="radioModel === 'foo'" class="w-max">
           <div class="p-24 flex">
             <w-dead-toggle radio v-model="radioModel" value="foo" />
             <w-clickable radio value="foo" v-model="radioModel" label-class="ml-12" name="radio-group">Radio in a card - A</w-clickable>
@@ -71,8 +72,10 @@
           </div>
         </w-card>
       </div>
-      <h3>Dead toggles</h3>
-      <div class="component flex gap-10">
+    </div>
+    <div>
+      <h3 class="h4">Dead toggles</h3>
+      <div class="flex gap-10">
         <w-card flat class="py-4 px-12 flex items-center" :selected="foo === 'foo'">
           <w-dead-toggle radio v-model="foo" value="foo" />
           <div class="ml-12">
@@ -88,5 +91,6 @@
           </div>
         </w-card>
       </div>
-
+    </div>
+  </div>
 </template>

--- a/docs/components/card/elements.md
+++ b/docs/components/card/elements.md
@@ -1,29 +1,27 @@
-## Syntax
+### Syntax
 
-```js
+```html
 <w-card selected="">
   <div class="m-20">This example shows a card that looks selected</div>
 </w-card>
 ```
 
-## Props
+### Props
 
 <api-table type=elements component="Card" />
 
-### Selected
+#### Selected
 
 You can control whether the card looks "selected" by setting the `selected` attribute OR property.
 
-#### Attribute
-
+Attribute:
 ```html example
 <w-card selected="">
   <div class="m-20">This example shows a card that looks selected</div>
 </w-card>
 ```
 
-#### Property
-
+Property:
 ```html example
 <w-card id="card-selected-property-example">
   <div class="m-20">This example shows a card that looks selected</div>
@@ -31,17 +29,17 @@ You can control whether the card looks "selected" by setting the `selected` attr
 <script>document.querySelector('#card-selected-property-example').selected = true;</script>
 ```
 
-### Clickable
+#### Clickable
 
 Whenever you add event listeners or use the onclick attribute, you should set the component's `clickable` attribute. This ensures that things such as keyboard navigation works as expected.
 
-```jsx example
+```html example
 <w-card clickable="" onclick="alert('clicked!');">
   <div class="m-20">This example shows content as a clickable div</div>
 </w-card>
 ```
 
-### Flat
+#### Flat
 
 If you need to give the component a flat look, set the `flat` attribute.
 
@@ -51,9 +49,9 @@ If you need to give the component a flat look, set the `flat` attribute.
 </w-card>
 ```
 
-## Examples
+### Examples
 
-### Semantics
+#### Semantics
 
 When you need the component to behave like a section, article or what have you, you should set the `role` attribute.
 
@@ -63,7 +61,7 @@ When you need the component to behave like a section, article or what have you, 
 </w-card>
 ```
 
-### Click event handler example
+#### Click event handler example
 
 You can register click events with onclick or addEventListener as per any other HTML element. When you do so, be sure to set the `clickable` attribute on the element for styling and accessibility reasons.
 
@@ -84,7 +82,7 @@ You can register click events with onclick or addEventListener as per any other 
     <p class="text-14 text-gray-400 mb-4">Bøgata 25C, 0655 Oslo</p>
     <p class="font-bold my-8">
       52 m
-      <span style="font-size: 10px; vertical-align: 'super'; margin-right: 5px">
+      <span style="font-size: 10px; vertical-align: super; margin-right: 5px">
         2 </span>
       Totalpris: 4 869 039 kr
     </p>
@@ -96,7 +94,7 @@ You can register click events with onclick or addEventListener as per any other 
 </w-card>
 ```
 
-### Anchor link example
+#### Anchor link example
 
 Keep in mind that if you wish to make the Card a clickable anchor card, you must add a div as the very first element with the attribute `aria-owns` set to the id of the title element. In this example we set it to the id of `title` and assign the `h3` this id.
 
@@ -114,7 +112,6 @@ You should follow these semantics, but styling is up to you.
 ```
 
 Full code example:
-
 ```html example
 <w-card class="mt-10 mr-10">
   <div aria-owns="title"></div>
@@ -138,7 +135,7 @@ Full code example:
     <p class="text-14 text-gray-400 mb-4">Bøgata 25C, 0655 Oslo</p>
     <p class="font-bold my-8">
       52 m
-      <span style="font-size: 10px; vertical-align: 'super'; margin-right: 5px">
+      <span style="font-size: 10px; vertical-align: super; margin-right: 5px">
         2 </span>
       Totalpris: 4 869 039 kr
     </p>

--- a/docs/components/card/index.md
+++ b/docs/components/card/index.md
@@ -16,6 +16,12 @@ Card is a layout component used for a traditional card look and feel.
 
 <card-example />
 
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
+
 ## Frameworks
 
 <tabs-content>

--- a/docs/components/card/react.md
+++ b/docs/components/card/react.md
@@ -1,18 +1,18 @@
-## Import
+### Import
 
 ```js
 import { Card } from '@warp-ds/react';
 ```
 
-## Props
+### Props
 
 <api-table type=react component="Card" />
 
-## DeadToggle props
+### DeadToggle props
 
 <api-table type=react component="DeadToggle" />
 
-## Code
+### Code
 
 The `<Card>` component takes any set of JSX elements as its children.
 
@@ -55,12 +55,11 @@ The `<Card>` component takes any set of JSX elements as its children.
 </Card>
 ```
 
-## Selecting
+### Selecting
 
-You can mark a Card as selected by pasing the `selected` property. This will add an outline to indicate the selected state.
+You can mark a Card as selected by passing the `selected` property. This will add an outline to indicate the selected state.
 
 Try clicking one of the cards below and watch them all get selected at once.
-
 
 ```jsx example
 function Example() {
@@ -178,7 +177,7 @@ function Example() {
 }
 ```
 
-## Anchor Cards
+### Anchor Cards
 
 Keep in mind that if you wish to make the Card a clickable anchor card, you must add a div as the very first element with the attribute aria-owns set to the id of the title element. In this example we set it to the id of title and assign the h3 this id.
 
@@ -245,7 +244,7 @@ Here's the full code example:
 </Card>
 ```
 
-## Toggles inside of Cards
+### Toggles inside of Cards
 
 Using Toggles([Radios](/components/radio/) or [Checkboxes](/components/checkbox/)) inside of cards has the limitation of only being able to pass forward a label. If you wish to further enhance the look and feel of these you must use the DeadToggle helper component, which we cover a bit further down.
 
@@ -296,7 +295,7 @@ function Example() {
 }
 ```
 
-## Using the DeadToggle and Clickable helper component
+### Using the DeadToggle and Clickable helper component
 
 First we must import the necessary helper components:
 

--- a/docs/components/card/vue.md
+++ b/docs/components/card/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 ```js
@@ -11,6 +11,6 @@ app.use(Card)
 import { wCard } from '@warp-ds/vue'
 ```
 
-## Props
+### Props
 
 <api-table type=vue component="Card"/>

--- a/docs/components/checkbox/Example.vue
+++ b/docs/components/checkbox/Example.vue
@@ -14,16 +14,18 @@
 </script>
 
 <template>
-  <h3>Default</h3>
-  <div class="component">
-    <w-toggle checkbox v-model="toggleModel" label="A very toggly label" :toggles="toggles" />
-  </div>
-  <h3>Disabled</h3>
-  <div class="component">
-    <w-toggle checkbox disabled v-model="disabledToggleModel" label="A very DISABLED non-toggly label" :toggles="toggles" />
-  </div>  
-  <h3>Invalid</h3>
-  <div class="component">
-    <w-toggle checkbox invalid v-model="invalidToggleModel" label="A very INVALID toggly label" :toggles="toggles" />
+  <div class="component space-y-16">
+    <div>
+      <h3 class="h4">Default</h3>
+      <w-toggle checkbox v-model="toggleModel" label="A very toggly label" :toggles="toggles" />
+    </div>
+    <div>
+      <h3 class="h4">Disabled</h3>
+      <w-toggle checkbox disabled v-model="disabledToggleModel" label="A very DISABLED non-toggly label" :toggles="toggles" />
+    </div>
+    <div>
+      <h3 class="h4">Invalid</h3>
+      <w-toggle checkbox invalid v-model="invalidToggleModel" label="A very INVALID toggly label" :toggles="toggles" />
+    </div>
   </div>
 </template>

--- a/docs/components/checkbox/index.md
+++ b/docs/components/checkbox/index.md
@@ -15,6 +15,12 @@ Checkboxes allow users to select multiple items from a list of individual items,
 
 <checkbox-example />
 
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
+
 ## Frameworks
 
 <tabs-content>
@@ -23,7 +29,5 @@ Checkboxes allow users to select multiple items from a list of individual items,
   </template>
   <template #vue>
     <vue />
-  </template>
-  <template #elements>
   </template>
 </tabs-content>

--- a/docs/components/checkbox/react.md
+++ b/docs/components/checkbox/react.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 The toggle component allows you to render checkboxes. All you have to do is specify `type="checkbox"` for the Toggle and let the component handle the rest. Toggle is built to handle both single and multiple options.
 
@@ -9,7 +9,7 @@ You must keep track of state yourself. The state has to be handled differently d
 import { Toggle } from '@warp-ds/react';
 ```
 
-## Props
+### Props
 
 <api-table type=react component="Toggle" />
 
@@ -20,7 +20,7 @@ type ToggleEntry = {
 };
 ```
 
-## Checkbox with single option
+### Checkbox with single option
 
 When you only want a single option, please use the `label` property over passing a single option to the `options` property. This results in the `onChange` callback function returning a single boolean value indicating the current state of the toggle.
 
@@ -46,7 +46,7 @@ function Example() {
 
 **Note** the `onChange` property returning a boolean value. This is because we're working with a single option. When using the `options` property, as seen in examples below, the option which has been selected is returned on the callback and we must handle this state ourselves.
 
-## Checkbox with multiple options
+### Checkbox with multiple options
 
 Let's have a look at using the Toggle with multiple options. As mentioned above, using the `options` property will change the returning value of the `onChange` callback. It will now return the option which was selected.
 
@@ -87,7 +87,7 @@ function Example() {
 **Note** the `title` property. This gives you the option to label the options, but is not required.
 
 
-## Checkbox with invisible label
+### Checkbox with invisible label
 
 You can hide the label by passing a `noVisibleLabel` prop to Toggle component.
 
@@ -111,7 +111,7 @@ function Example() {
 }
 ```
 
-## Checkbox with indeterminate state
+### Checkbox with indeterminate state
 
 Sometimes we need to indicate that the state of a single checkbox is indeterminate, or "partially checked". The checkbox will appear with a small dash instead of a tick to indicate that the option is not exactly checked or unchecked.
 
@@ -179,7 +179,7 @@ function Example() {
 }
 ```
 
-## Validation
+### Validation
 
 Validation is as easy as passing the property `invalid` with a `helpText` to further explain the error. `helpText` can also be used as an assistance label before an error occurs as long as `invalid` is set to false.
 

--- a/docs/components/checkbox/vue.md
+++ b/docs/components/checkbox/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 ```js
@@ -11,23 +11,23 @@ app.use(Forms)
 import { wToggle } from '@warp-ds/vue'
 ```
 
-## Syntax
+### Syntax
 
-```html
+```vue
 <w-toggle checkbox v-model="model" label="A label" :toggles="[
   { label: 'One', value: 1 },
   { label: 'Two', value: 2 }
 ]" />
 ```
 
-## Props
+### Props
 
 The props documented below have defaults set or are unique to this component, all typical HTML5 attributes are valid props. See Field for additional props.
 
 <api-table type=vue component="Toggle"/>
 
-## Validation
-### Validating Elements
+### Validation
+#### Validating Elements
 Every form element accepts a prop rules which takes an array of functions. These functions will be run in order until one returns an object. If all functions return true the field is considered valid.
 
 ```js
@@ -38,12 +38,12 @@ The function has one argument, the current value of the form element — and can
 
 <api-table type=vue component="InputAttributes"/>
 
-### Collecting Validation from wForm
+#### Collecting Validation from wForm
 The wForm component registers element descendants at any level, and provides the aggregate validation status.
 
 <api-table type=vue component="InputValidation"/>
 
-### Programmatic validation
+#### Programmatic validation
 The wField component can provide access to programmatic validation beyond what wForm's props can. For information on which methods are available, see the documentation on Field.
 
 ```html
@@ -52,7 +52,6 @@ The wField component can provide access to programmatic validation beyond what w
 </w-field>
 ```
 
-### Validation and required Form Elements
+#### Validation and required Form Elements
 If the form element is marked `required`, a special rule will be inserted before any user-defined rules.
 The `required` prop can accept a function that will be used as the required-rule.
-

--- a/docs/components/combobox/index.md
+++ b/docs/components/combobox/index.md
@@ -4,7 +4,10 @@
 
 # Combobox (also known as an autocomplete or autosuggest)
 
-A combobox is the combination of an `<input type="text"/>` and a list. The list is designed to help the user arrive at a value, but the value does not necessarily have to come from that list. Don't think of it like a `<select/>`, but more of an input with some suggestions. You can, however, validate that the value comes from the list, that's up to your app.
+A combobox is the combination of an `<input type="text"/>` and a list.
+The list is designed to help the user arrive at a value, but the value does not necessarily have to come from that list.
+Don't think of it like a `<select/>`, but more of an input with some suggestions.
+You can, however, validate that the value comes from the list, that's up to your app.
 
 <components-status react='released' />
 
@@ -12,14 +15,16 @@ A combobox is the combination of an `<input type="text"/>` and a list. The list 
 
 ![Combobox](/combobox.png)
 
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
+
 ## Frameworks
 
 <tabs-content>
   <template #react>
-   <react />
-  </template>
-  <template #vue>
-  </template>
-  <template #elements>
+    <react />
   </template>
 </tabs-content>

--- a/docs/components/combobox/index.md
+++ b/docs/components/combobox/index.md
@@ -17,8 +17,6 @@ You can, however, validate that the value comes from the list, that's up to your
 
 ## Usage
 
-<component-design-guidelines name="Warp - Components / Choice List" link="https://www.figma.com/file/nkiRpuVu6XRfvY96BA80H8/Components-overview?type=design&node-id=259-14517&mode=design" />
-
 <component-questions />
 
 ## Frameworks

--- a/docs/components/combobox/react.md
+++ b/docs/components/combobox/react.md
@@ -1,10 +1,10 @@
-## Import
+### Import
 
 ```js
 import { Combobox } from '@warp-ds/react';
 ```
 
-## Props
+### Props
 
 <api-table type=react component="Combobox" />
 
@@ -15,7 +15,7 @@ export type ComboboxOption = {
 };
 ```
 
-## Example
+### Example
 
 ```jsx
 function Example() {
@@ -38,7 +38,7 @@ function Example() {
 }
 ```
 
-## Highlight matched text segments
+### Highlight matched text segments
 
 If you want to highlight the matched text you can set the `matchTextSegments` prop.
 
@@ -77,21 +77,19 @@ The `matchTextSegments` uses the default algorithm for input/option matching. To
 ```jsx
 // PSEUDO CODE
 function highlightValueMatch(optionValue: string, inputValue: string) {
-    // ADDITIONAL CODE?
-    if match // return JSX string value with additional visual styling
-    else // return JSX string value
-  });
+  // ADDITIONAL CODE?
+  if (match) ;// return JSX string value with additional visual styling
+  else ;// return JSX string value
 }
 ```
 
-## Asynchronous option fetching
+### Asynchronous option fetching
 
 When you fetch options asynchronously, it is often preferred to pass the `disableStaticFiltering` prop so that you don't filter the options client side.
 
-## Custom rendering in ComboboxOption
+### Custom rendering in ComboboxOption
 
 Sometimes you need to render something other than the value as the visible option, in these cases you can pass a `label`. The label is only for display. The `value` is what gets sent back when selected.
-
 
 ```jsx
 function Example() {
@@ -116,7 +114,7 @@ function Example() {
 }
 ```
 
-## Client side search
+### Client side search
 
 This example searches an API of Star Wars characters. Combobox does not implement any matching on your list (aside from highlighting the matched phrases in an option). Instead, you render an option for each result you want in the list. So your job is to:
 
@@ -183,7 +181,7 @@ function Example() {
 }
 ```
 
-## Affix
+### Affix
 
 If you wish to use an affix you must first import the Affix component.
 
@@ -191,7 +189,7 @@ If you wish to use an affix you must first import the Affix component.
 import { Affix } from '@warp-ds/react';
 ```
 
-Then you include it as a child of Combobox component and pass the appropiate props (see bottom of this page for types)
+Then you include it as a child of Combobox component and pass the appropriate props (see bottom of this page for types).
 
 ```jsx
 function Example() {
@@ -223,11 +221,12 @@ function Example() {
 }
 ```
 
-*Note* that when using the Affix component without a `label` you should specify an `aria-label`. See props at the bottom of this page. See [TextField](/components/textfield/) for more details on Affix.
+*Note* that when using the Affix component without a `label` you should specify an `aria-label`.
+See props at the bottom of this page. See [TextField](/components/textfield/) for more details on Affix.
 
 <api-table type=react component="Affix" />
 
-## Clearing input on select
+### Clearing input on select
 
 If you want, you can have the input field cleared after a value has been selected:
 
@@ -255,7 +254,7 @@ function Example() {
 }
 ```
 
-## Optional prop
+### Optional prop
 
 Add the optional prop to indicate that the combobox field is not required.
 

--- a/docs/components/expandable/Example.vue
+++ b/docs/components/expandable/Example.vue
@@ -3,22 +3,24 @@ import { wExpandable } from '@warp-ds/vue';
 </script>
 
 <template>
-  <div class="component">
-    <h3>Default</h3>
-    <w-expandable title="I am expandable">
-      <p>Expandable contents go here.</p>
-    </w-expandable>
-  </div>
-  <div class="component">
-    <h3>Expandable box</h3>
-    <w-expandable title="I am an expandable box" box>
-      <p>Expandable contents go here.</p>
-    </w-expandable>
-  </div>
-  <div class="component">
-    <h3>Expandable animated box</h3>
-    <w-expandable title="I am an expandable info box" animated box>
-      <p>Expandable contents go here.</p>
-    </w-expandable>
+  <div class="component space-y-16">
+    <div>
+      <h3 class="h4">Default</h3>
+      <w-expandable title="I am expandable">
+        <p>Expandable contents go here.</p>
+      </w-expandable>
+    </div>
+    <div>
+      <h3 class="h4">Expandable box</h3>
+      <w-expandable title="I am an expandable box" box>
+        <p>Expandable contents go here.</p>
+      </w-expandable>
+    </div>
+    <div>
+      <h3 class="h4">Expandable animated box</h3>
+      <w-expandable title="I am an expandable info box" animated box>
+        <p>Expandable contents go here.</p>
+      </w-expandable>
+    </div>
   </div>
 </template>

--- a/docs/components/expandable/elements.md
+++ b/docs/components/expandable/elements.md
@@ -1,26 +1,26 @@
-## Visual options
+### Visual options
 
-### Default
+#### Default
 
-```js
+```html
 <w-expandable title="I'm expandable">
   <p>with expanded content</p>
 </w-expandable>
 ```
 
-### Expandable box
+#### Expandable box
 
-```js
+```html
 <w-expandable title="I'm expandable" box>
   <p>with expanded content</p>
 </w-expandable>
 ```
 
-### Expandable box with custom title
+#### Expandable box with custom title
 
 This can be used if more control over styling is needed than the `title` prop allows
 
-```js
+```html
 <w-expandable box>
   <div slot="title" class="flex flex-row items-center">
     <f-icon-bag16></f-icon-bag16>
@@ -30,14 +30,14 @@ This can be used if more control over styling is needed than the `title` prop al
 </w-expandable>
 ```
 
-### With expanded prop
+#### With expanded prop
 
-```js
+```html
 <w-expandable box info title="I'm expanded by default" expanded>
   <p>content should be visible</p>
 </w-expandable>
 ```
 
-## Props
+### Props
 
 <api-table type="elements" component="Expandable" />

--- a/docs/components/expandable/index.md
+++ b/docs/components/expandable/index.md
@@ -8,14 +8,19 @@
 
 Expandable is a layout component used for creating expandable content areas on a page.
 
-
 <components-status react='released' vue='released' elements='released' />
 
 ## Examples
 
 <theme-switcher />
 
-<expandable-example></expandable-example>
+<expandable-example />
+
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
 
 ## Frameworks
 

--- a/docs/components/expandable/react.md
+++ b/docs/components/expandable/react.md
@@ -1,12 +1,12 @@
-## Import
+### Import
 
 ```js
 import { Expandable } from '@warp-ds/react';
 ```
 
-## Visual options
+### Visual options
 
-### Default
+#### Default
 
 ```js
 <Expandable title="I am expandable">
@@ -14,7 +14,7 @@ import { Expandable } from '@warp-ds/react';
 </Expandable>
 ```
 
-### Expandable box
+#### Expandable box
 
 ```js
 <Expandable title="I am expandable box" box>
@@ -22,7 +22,7 @@ import { Expandable } from '@warp-ds/react';
 </Expandable>
 ```
 
-### Expandable box with icon
+#### Expandable box with icon
 
 ```js
 import { IconBag16 } from '@fabric-ds/icons/react';
@@ -41,7 +41,7 @@ import { IconBag16 } from '@fabric-ds/icons/react';
 </Expandable>;
 ```
 
-### Expandable animated box
+#### Expandable animated box
 
 ```js
 <Expandable title="I am expandable animated box" box animated>
@@ -49,7 +49,7 @@ import { IconBag16 } from '@fabric-ds/icons/react';
 </Expandable>
 ```
 
-### The expanded prop
+#### The expanded prop
 
 You can set whether the component is open or collapsed using the `expanded` prop.
 
@@ -59,7 +59,7 @@ You can set whether the component is open or collapsed using the `expanded` prop
 </Expandable>
 ```
 
-### onChange event
+#### onChange event
 
 ```js
 <Expandable title="I am expandable" onChange={(state) => console.log(state)}>
@@ -68,7 +68,7 @@ You can set whether the component is open or collapsed using the `expanded` prop
 </Expandable>
 ```
 
-### Controlling the component
+#### Controlling the component
 
 If you need to take control of expansion, use the `onChange` event in combination with the `expanded` prop.
 
@@ -84,6 +84,6 @@ function Example() {
 }
 ```
 
-## Props
+### Props
 
 <api-table type="react" component="Expandable" />

--- a/docs/components/expandable/vue.md
+++ b/docs/components/expandable/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 
@@ -13,39 +13,39 @@ app.use(Expandable);
 import { wExpandable, wExpandTransition, wWillExpand } from '@warp-ds/vue';
 ```
 
-## Syntax
+### Syntax
 
-```js
+```vue
 <w-expandable title="I am expandable">
   <p>Hello there I am some informative content</p>
 </w-expandable>
 ```
 
-## Visual options
+### Visual options
 
-### Default
+#### Default
 
-```js
+```vue
 <w-expandable title="I am expandable">
   <p>Hello there I am some informative content</p>
 </w-expandable>
 ```
 
-### Expandable box
+#### Expandable box
 
-```js
+```vue
 <w-expandable title="I am expandable" box>
   <p>Hello there I am some informative content</p>
 </w-expandable>
 ```
 
-## Animation
+### Animation
 
-### You should only use this feature under careful supervision of your friendly local UXer.
+#### You should only use this feature under careful supervision of your friendly local UXer.
 
 The w-expandable component can be animated using the animated prop.
 
-```js
+```vue
 <w-expandable animated title="I am expandable">
   <p>Hello there I am some informative content</p>
 </w-expandable>
@@ -53,13 +53,13 @@ The w-expandable component can be animated using the animated prop.
 
 The wExpandTransition component can wrap one or more wWillExpand components.
 
-```js
+```vue
 <w-expand-transition group>
   <w-will-expand v-if="expanded">Hello</w-will-expand>
   <w-will-expand v-else>Hi</w-will-expand>
 <w-expand-transition>
 ```
 
-## Props
+### Props
 
 <api-table type="vue" component="Expandable" />

--- a/docs/components/icons/elements.md
+++ b/docs/components/icons/elements.md
@@ -1,15 +1,15 @@
-## Import
+### Import
 
 ```js
 import '@warp-ds/icons/elements/bag-16';
 ```
 
-### Usage
+### Syntax
 
 ```html
-  <w-icon-bag16></w-icon-bag16>
+<w-icon-bag16></w-icon-bag16>
 ```
 
 ### Colors
-
-The color of the icon will default to `currentColor`. Colors can be changed using semantic color classes for icons listed [here](https://warp-ds.github.io/css-docs/icon-color#icon-color).
+The color of the icon will default to `currentColor`.
+Colors can be changed using [semantic color classes for icons](https://warp-ds.github.io/css-docs/icon-color#icon-color).

--- a/docs/components/icons/index.md
+++ b/docs/components/icons/index.md
@@ -8,8 +8,19 @@
 
 Warp's icon set is designed to help users understand actions, information and draw attention to elements.
 
-
 <components-status react='released' vue='released' elements='released' />
+
+## Examples
+
+<theme-switcher />
+
+<icon-example />
+
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
 
 ## Frameworks
 
@@ -24,10 +35,3 @@ Warp's icon set is designed to help users understand actions, information and dr
     <elements />
   </template>
 </tabs-content>
-
-## Examples
-
-<theme-switcher />
-
-<icon-example></icon-example>
-

--- a/docs/components/icons/index.md
+++ b/docs/components/icons/index.md
@@ -18,7 +18,7 @@ Warp's icon set is designed to help users understand actions, information and dr
 
 ## Usage
 
-<component-design-guidelines name="Warp - Components / Icons" link="" />
+<component-design-guidelines name="Warp - Components / Icons" link="https://www.figma.com/file/yEx16ew6S0Xgd579dN4hsM/Warp---Icons?type=design&node-id=6011-1442&mode=design&t=zY5N398IPei2z89J-0" />
 
 <component-questions />
 

--- a/docs/components/icons/react.md
+++ b/docs/components/icons/react.md
@@ -1,15 +1,15 @@
-## Import
+### Import
 
 ```js
 import { IconBag16 } from '@warp-ds/icons/react';
 ```
 
-### Usage
+### Syntax
 
-```html
-  <IconBag16 />
+```jsx
+<IconBag16 />
 ```
 
 ### Colors
-
-The color of the icon will default to `currentColor`. Colors can be changed using semantic color classes for icons listed [here](https://warp-ds.github.io/css-docs/icon-color#icon-color).
+The color of the icon will default to `currentColor`.
+Colors can be changed using [semantic color classes for icons](https://warp-ds.github.io/css-docs/icon-color#icon-color).

--- a/docs/components/icons/vue.md
+++ b/docs/components/icons/vue.md
@@ -1,15 +1,16 @@
-## Import
+### Import
 
 ```js
 import { IconBag16 } from '@warp-ds/icons/vue';
 ```
 
-### Usage
+### Syntax
 
 ```html
-  <icon-bag16 />
+<icon-bag16 />
 ```
 
 ### Colors
 
-The color of the icon will default to `currentColor`. Colors can be changed using semantic color classes for icons listed [here](https://warp-ds.github.io/css-docs/icon-color#icon-color).
+The color of the icon will default to `currentColor`. 
+Colors can be changed using [semantic color classes for icons](https://warp-ds.github.io/css-docs/icon-color#icon-color).

--- a/docs/components/modal/Example.vue
+++ b/docs/components/modal/Example.vue
@@ -15,25 +15,27 @@ const changeHeight = () => heightToggle.value = !heightToggle.value
 </script>
 
 <template>
-  <h3>Default</h3>
-  <div class="component flex gap-10">
-    <w-modal title="Hello Warp!" :style="demoStyles" :left="showLeft" :right="{ 'aria-label': 'Close' }" @dismiss="showModal = false" v-model="showModal" @right="showModal = false">
-      <div class="space-x-8">
-        <w-button utility @click="changeHeight" small class="mb-32">Modify height</w-button>
-        <w-button utility @click="showLeft = !showLeft" small class="mb-32">Toggle the back-button</w-button>
-      </div>
-      <div v-once>
-        <h1 class="h4 mb-16">This is a title for the content area</h1>
-        <p>Life as a shorty shouldn't be so rough. Behold the bold soldier control the globe slowly, proceeds to blow, swinging swords like Shinobi. The game of chess, is like a swordfight, you must think first before you move. My beats travel like a vortex through your spine, to the top of your cerebral cortex. I smoke on the mic like smoking Joe Frazier, the hell raiser, raising hell with the flavor.</p>
-        <p>I breaks it down to the bone gristle, Ill speaking Scud missile heat seeking, Johnny Blazing. Protect Ya Neck, my sword still remain imperial before I blast the mic, RZA scratch off the serial. Shackling the masses with drastic rap tactics, graphic displays melt the steel like blacksmiths. Perpendicular to the square we stay in gold like Flair, escape from your dragon's lair in particular. Shame on you when you stepped through to The Ol Dirty Bastard straight from the Brooklyn Zoo. Protect Ya Neck, my sword still remain imperial before I blast the mic, RZA scratch off the serial.</p>
-        <p>Handcuffed in the back of a bus, forty of us. Rae got it going on pal, call me the rap assassinator, rhymes rugged and built like Schwarzenegger. My beats travel like a vortex through your spine, to the top of your cerebral cortex. Well I'm a sire, I set the microphone on fire, rap styles vary and carry like Mariah.</p>
-        <p>Small change, they putting shame in the game. My beats travel like a vortex through your spine, to the top of your cerebral cortex. Shame on you when you stepped through to The Ol Dirty Bastard straight from the Brooklyn Zoo. I come rough, tough like an Elephant tusk. I bomb atomically Socrates' philosophies and hypothesis can't define how I be dropping these mockeries. The rebel, I make more noise than heavy metal. Cash rules everything around me, dollar dollar bill, ya'll. If what you say is true, the Shaolin and the Wu-Tang could be dangerous.</p>
-        <p>Perpendicular to the square we stay in gold like Flair, escape from your dragon's lair in particular. The game of chess, is like a swordfight, you must think first before you move. Leave it up to me while I be livin' proof I smoke on the mic like smoking Joe Frazier, the hell raiser, raising hell with the flavor. Step through your section with the Force like Luke Skywalker, rhyme author, orchestrate mind torture. Feeling mad hostile, ran the apostle, flowing like Christ when I speak the gospel. Well I'm a sire, I set the microphone on fire, rap styles vary and carry like Mariah. I grew up on the crime side, the New York Times side, Stayin' alive was no jive.</p>
-      </div>
-      <template #footer>
-        <w-button primary @click="showModal = false">Click me</w-button>
-      </template>
-    </w-modal>
-    <w-button utility @click="showModal = true">Show modal</w-button>
+  <div class="component">
+    <h3 class="h4">Default</h3>
+    <div class="flex gap-10">
+      <w-modal title="Hello Warp!" :style="demoStyles" :left="showLeft" :right="{ 'aria-label': 'Close' }" @dismiss="showModal = false" v-model="showModal" @right="showModal = false">
+        <div class="space-x-8">
+          <w-button utility @click="changeHeight" small class="mb-32">Modify height</w-button>
+          <w-button utility @click="showLeft = !showLeft" small class="mb-32">Toggle the back-button</w-button>
+        </div>
+        <div v-once>
+          <h1 class="h4 mb-16">This is a title for the content area</h1>
+          <p>Life as a shorty shouldn't be so rough. Behold the bold soldier control the globe slowly, proceeds to blow, swinging swords like Shinobi. The game of chess, is like a swordfight, you must think first before you move. My beats travel like a vortex through your spine, to the top of your cerebral cortex. I smoke on the mic like smoking Joe Frazier, the hell raiser, raising hell with the flavor.</p>
+          <p>I breaks it down to the bone gristle, Ill speaking Scud missile heat seeking, Johnny Blazing. Protect Ya Neck, my sword still remain imperial before I blast the mic, RZA scratch off the serial. Shackling the masses with drastic rap tactics, graphic displays melt the steel like blacksmiths. Perpendicular to the square we stay in gold like Flair, escape from your dragon's lair in particular. Shame on you when you stepped through to The Ol Dirty Bastard straight from the Brooklyn Zoo. Protect Ya Neck, my sword still remain imperial before I blast the mic, RZA scratch off the serial.</p>
+          <p>Handcuffed in the back of a bus, forty of us. Rae got it going on pal, call me the rap assassinator, rhymes rugged and built like Schwarzenegger. My beats travel like a vortex through your spine, to the top of your cerebral cortex. Well I'm a sire, I set the microphone on fire, rap styles vary and carry like Mariah.</p>
+          <p>Small change, they putting shame in the game. My beats travel like a vortex through your spine, to the top of your cerebral cortex. Shame on you when you stepped through to The Ol Dirty Bastard straight from the Brooklyn Zoo. I come rough, tough like an Elephant tusk. I bomb atomically Socrates' philosophies and hypothesis can't define how I be dropping these mockeries. The rebel, I make more noise than heavy metal. Cash rules everything around me, dollar dollar bill, ya'll. If what you say is true, the Shaolin and the Wu-Tang could be dangerous.</p>
+          <p>Perpendicular to the square we stay in gold like Flair, escape from your dragon's lair in particular. The game of chess, is like a swordfight, you must think first before you move. Leave it up to me while I be livin' proof I smoke on the mic like smoking Joe Frazier, the hell raiser, raising hell with the flavor. Step through your section with the Force like Luke Skywalker, rhyme author, orchestrate mind torture. Feeling mad hostile, ran the apostle, flowing like Christ when I speak the gospel. Well I'm a sire, I set the microphone on fire, rap styles vary and carry like Mariah. I grew up on the crime side, the New York Times side, Stayin' alive was no jive.</p>
+        </div>
+        <template #footer>
+          <w-button primary @click="showModal = false">Click me</w-button>
+        </template>
+      </w-modal>
+      <w-button utility @click="showModal = true">Show modal</w-button>
+    </div>
   </div>
 </template>

--- a/docs/components/modal/index.md
+++ b/docs/components/modal/index.md
@@ -17,20 +17,22 @@ Modals (or dialogs) display important information that users need to acknowledge
 
 ## Usage
 
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
 ### Accessibility
 Modal needs either aria-label or aria-labelledby to be accessible to screen readers.
 
 All dialogs must have a title. Titles appear in bold at the top of the dialog and use a few words to convey the outcome of what will happen if a user continues with an action. Use the property title for this.
 
+<component-questions />
+
 ## Frameworks
 
 <tabs-content>
   <template #react>
-   <react />
+    <react />
   </template>
   <template #vue>
     <vue />
-  </template>
-  <template #elements>
   </template>
 </tabs-content>

--- a/docs/components/modal/react.md
+++ b/docs/components/modal/react.md
@@ -1,14 +1,14 @@
-## Import
+### Import
 
 ```js
 import { Modal } from '@warp-ds/react';
 ```
 
-## Props
+### Props
 
 <api-table type=react component="Modal" />
 
-## Example
+### Example
 
 ```jsx
 function Example() {
@@ -90,15 +90,16 @@ function Example() {
 }
 ```
 
-## Content
+### Content
 
 WARP guidelines state the following:
 
 - The cancel action should always be on the left, while the main action is to the right.
 
-## Non dismissable modals
+### Non dismissable modals
 
-The `onDismiss` prop is optional. It can be dropped to create a modal that won't respond to `esc` keypresses and/or clicking outside the modal.
+The `onDismiss` prop is optional.
+It can be dropped to create a modal that won't respond to `esc` key presses and/or clicking outside the modal.
 
 ```jsx
 function Example() {
@@ -147,9 +148,11 @@ function Example() {
 }
 ```
 
-## Customizing focus behavior
+### Customizing focus behavior
 
-By default the first interactive element in the modal will be focused when the modal opens. Use `initialFocusRef` to customize this behavior. For instance, this can be used to focus a call to action button.
+By default, the first interactive element in the modal will be focused when the modal opens.
+Use `initialFocusRef` to customize this behavior.
+For instance, this can be used to focus a call-to-action button.
 
 ```jsx
 function Example() {

--- a/docs/components/modal/vue.md
+++ b/docs/components/modal/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 ```js
@@ -11,25 +11,26 @@ app.use(Modal)
 import { wModal } from '@warp-ds/vue'
 ```
 
-## Props
+### Props
 
 <api-table type=vue component="Modal"/>
 
-### Slots
+#### Slots
 
 Note that to dynamically control the left/right slots, one must use the left/right props instead of showing and hiding the slot itself.
 
 <api-table type=vue component="ModalSlots"/>
 
-### Custom Properties
+#### Custom Properties
 
-Use percentage-based units as opposed to `vh` for adjusting heights. This ensures correct behavior on mobile devices when toolbars show/hide and cause changes to the inner height.
+Use percentage-based units as opposed to `vh` for adjusting heights.
+This ensures correct behavior on mobile devices when toolbars show/hide and cause changes to the inner height.
 
 <api-table type=vue component="ModalCustomProperties"/>
 
-## Example
+### Example
 
-```html
+```vue
 <w-modal @dismiss="modalIsOpen = false" v-model="modalIsOpen">
   <h1>Hello I am a modal</h1>
 </w-modal>

--- a/docs/components/pill/index.md
+++ b/docs/components/pill/index.md
@@ -3,9 +3,7 @@
   import React from './react.md';
 </script>
 
-
 # Pill
-
 
 Pill is a type of button that is often used as a filter, but can also be used as a rounded button for overlays, etc.
 
@@ -17,6 +15,12 @@ Pill is a type of button that is often used as a filter, but can also be used as
 
 <pill-example />
 
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
+
 ## Frameworks
 
 <tabs-content> 
@@ -25,7 +29,5 @@ Pill is a type of button that is often used as a filter, but can also be used as
   </template>
   <template #vue>
     <vue />
-  </template>
-  <template #elements>
   </template>
 </tabs-content>

--- a/docs/components/pill/react.md
+++ b/docs/components/pill/react.md
@@ -1,15 +1,15 @@
-## Import
+### Import
 
 ```js
 import { Pill } from "@warp-ds/react";
 ```
 
-## Syntax
+### Syntax
 
-```js
+```jsx
 <Pill suggestion label="Suggestion pill" />
 ```
 
-## Props
+### Props
 
 <api-table type="react" component="Pill" />

--- a/docs/components/pill/vue.md
+++ b/docs/components/pill/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 
@@ -13,12 +13,12 @@ app.use(Pill);
 import { wPill } from "@warp-ds/vue";
 ```
 
-## Syntax
+### Syntax
 
-```js
+```vue
 <w-pill suggestion label="Suggestion pill" />
 ```
 
-## Props
+### Props
 
 <api-table type=vue component="Pill" />

--- a/docs/components/radio/Example.vue
+++ b/docs/components/radio/Example.vue
@@ -14,16 +14,18 @@
 </script>
 
 <template>
-  <h3>Default</h3>
-  <div class="component">
-    <w-toggle radio v-model="toggleModel" label="A very toggly label" :toggles="toggles" />
-  </div>
-  <h3>Disabled</h3>
-  <div class="component">
-    <w-toggle radio disabled v-model="disabledToggleModel" label="A very DISABLED non-toggly label" :toggles="toggles" />
-  </div>  
-  <h3>Invalid</h3>
-  <div class="component">
-    <w-toggle radio invalid v-model="invalidToggleModel" label="A very INVALID toggly label" :toggles="toggles" />
+  <div class="component space-y-16">
+    <div>
+      <h3 class="h4">Default</h3>
+      <w-toggle radio v-model="toggleModel" label="A very toggly label" :toggles="toggles" />
+    </div>
+    <div>
+      <h3 class="h4">Disabled</h3>
+      <w-toggle radio disabled v-model="disabledToggleModel" label="A very DISABLED non-toggly label" :toggles="toggles" />
+    </div>
+    <div>
+      <h3 class="h4">Invalid</h3>
+      <w-toggle radio invalid v-model="invalidToggleModel" label="A very INVALID toggly label" :toggles="toggles" />
+    </div>
   </div>
 </template>

--- a/docs/components/radio/index.md
+++ b/docs/components/radio/index.md
@@ -15,6 +15,12 @@ Radios allow users to select a single option from a list of mutually exclusive o
 
 <radio-example />
 
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
+
 ## Frameworks
 
 <tabs-content>
@@ -23,7 +29,5 @@ Radios allow users to select a single option from a list of mutually exclusive o
   </template>
   <template #vue>
     <vue />
-  </template>
-  <template #elements>
   </template>
 </tabs-content>

--- a/docs/components/radio/react.md
+++ b/docs/components/radio/react.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 The toggle component allows you to render radios. All you have to do is specify `type="radio"` for the Toggle and let the component handle the rest. Toggle is built to handle both single and multiple options.
 
@@ -8,9 +8,9 @@ You must keep track of state yourself. The state has to be handled differently d
 import { Toggle } from '@warp-ds/react';
 ```
 
-## Props
+### Syntax
 
-<api-table type=react component="Toggle" />
+#### Radio with multiple options
 
 ```ts example
 type ToggleEntry = {
@@ -18,8 +18,6 @@ type ToggleEntry = {
   value: unknown;
 };
 ```
-
-## Radio with multiple options
 
 ```jsx example
 function Example() {
@@ -43,7 +41,11 @@ function Example() {
 
 Note the `helpText` property. This gives you the option to further explain the purpose of the toggle and the action to take.
 
-## Validation
+### Props
+
+<api-table type=react component="Toggle" />
+
+### Validation
 
 Validation is as easy as passing the property `invalid` with a `helpText` to further explain the error. `helpText` can also be used as an assistance label before an error occurs as long as `invalid` is set to false.
 

--- a/docs/components/radio/vue.md
+++ b/docs/components/radio/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 ```js
@@ -11,23 +11,23 @@ app.use(Forms)
 import { wToggle } from '@warp-ds/vue'
 ```
 
-## Syntax
+### Syntax
 
-```html
+```vue
 <w-toggle radio v-model="model" label="A label" :toggles="[
   { label: 'One', value: 1 },
   { label: 'Two', value: 2 }
 ]" />
 ```
 
-## Props
+### Props
 
 The props documented below have defaults set or are unique to this component, all typical HTML5 attributes are valid props. See Field for additional props.
 
 <api-table type=vue component="Toggle"/>
 
-## Validation
-### Validating Elements
+### Validation
+#### Validating Elements
 Every form element accepts a prop rules which takes an array of functions. These functions will be run in order until one returns an object. If all functions return true the field is considered valid.
 
 ```js
@@ -38,21 +38,21 @@ The function has one argument, the current value of the form element — and can
 
 <api-table type=vue component="InputAttributes"/>
 
-### Collecting Validation from wForm
+#### Collecting Validation from wForm
 The wForm component registers element descendants at any level, and provides the aggregate validation status.
 
 <api-table type=vue component="InputValidation"/>
 
-### Programmatic validation
+#### Programmatic validation
 The wField component can provide access to programmatic validation beyond what wForm's props can. For information on which methods are available, see the documentation on Field.
 
-```html
+```vue
 <w-field #control="{ form }">
   <button @click="submit(form)">Submit</button>
 </w-field>
 ```
 
-### Validation and required Form Elements
+#### Validation and required Form Elements
 If the form element is marked `required`, a special rule will be inserted before any user-defined rules.
 The `required` prop can accept a function that will be used as the required-rule.
 

--- a/docs/components/radiobuttons/Example.vue
+++ b/docs/components/radiobuttons/Example.vue
@@ -1,21 +1,23 @@
 <script setup>
-  import { wToggle, wButton } from '@warp-ds/vue';
-  import { ref } from 'vue';
+import { wToggle, wButton } from '@warp-ds/vue';
+import { ref } from 'vue';
 
-  const isJustified = ref(false);
-  const multiToggleModel = ref('');
+const isJustified = ref(false);
+const multiToggleModel = ref('');
 
-  const toggles = [
-    { label: 'One', value: 1, 'data-test': 'toggle:1' },
-    { label: 'Two', value: 2, 'data-test': 'toggle:2' },
-  ]
-
+const toggles = [
+  { label: 'One', value: 1, 'data-test': 'toggle:1' },
+  { label: 'Two', value: 2, 'data-test': 'toggle:2' },
+]
 </script>
 
 <template>
-  <h3>Default</h3>
   <div class="component">
-    <w-toggle radio-button :equal-width="isJustified" v-model="multiToggleModel" label="A very toggly label" :toggles="toggles" />
-    <w-button class="mt-16" small utility @click="isJustified = !isJustified">{{ isJustified ? 'Unjustify' : 'Justify' }}</w-button>
+    <h3 class="h4">Default</h3>
+    <w-toggle radio-button :equal-width="isJustified" v-model="multiToggleModel" label="A very toggly label" :toggles="toggles" class="mb-32" />
+
+    <demo-controls>
+      <w-button small utility @click="isJustified = !isJustified">{{ isJustified ? 'Unjustify' : 'Justify' }}</w-button>
+    </demo-controls>
   </div>
 </template>

--- a/docs/components/radiobuttons/index.md
+++ b/docs/components/radiobuttons/index.md
@@ -17,8 +17,6 @@ Radio buttons allow users to select a single option from a list of mutually excl
 
 ## Usage
 
-<component-design-guidelines name="Warp - Components / Radio Button" link="https://www.figma.com/file/nkiRpuVu6XRfvY96BA80H8/Components-overview?type=design&node-id=377-23900&mode=design" />
-
 <component-questions />
 
 ## Frameworks

--- a/docs/components/radiobuttons/index.md
+++ b/docs/components/radiobuttons/index.md
@@ -15,6 +15,12 @@ Radio buttons allow users to select a single option from a list of mutually excl
 
 <radiobuttons-example />
 
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
+
 ## Frameworks
 
 <tabs-content>
@@ -23,7 +29,5 @@ Radio buttons allow users to select a single option from a list of mutually excl
   </template>
   <template #vue>
     <vue />
-  </template>
-  <template #elements>
   </template>
 </tabs-content>

--- a/docs/components/radiobuttons/react.md
+++ b/docs/components/radiobuttons/react.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 The toggle component allows you to render radio buttons in a group. All you have to do is specify `type="radio-button"` for the Toggle and let the component handle the rest. Toggle is built to handle both single and multiple options.
 
@@ -8,7 +8,14 @@ You must keep track of state yourself. The state has to be handled differently d
 import { Toggle } from '@warp-ds/react';
 ```
 
-## React syntax
+### Syntax
+
+```ts example
+type ToggleEntry = {
+  label: string;
+  value: unknown;
+};
+```
 
 ```jsx example
 function Example() {
@@ -42,24 +49,15 @@ function Example() {
     </>
   );
 }
-
 ```
 
 Radio buttons have the special property `equalWidth`, which will render each option with equal width.
 
-
-## Props
+### Props
 
 <api-table type=react component="Toggle" />
 
-```ts example
-type ToggleEntry = {
-  label: string;
-  value: unknown;
-};
-```
-
-## Validation
+### Validation
 
 Validation is as easy as passing the property `invalid` with a `helpText` to further explain the error. `helpText` can also be used as an assistance label before an error occurs as long as `invalid` is set to false.
 

--- a/docs/components/radiobuttons/vue.md
+++ b/docs/components/radiobuttons/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 ```js
@@ -11,23 +11,24 @@ app.use(Forms)
 import { wToggle } from '@warp-ds/vue'
 ```
 
-## Syntax
+### Syntax
 
-```html
+```vue
 <w-toggle radio-button v-model="model" label="A label" :toggles="[
   { label: 'One', value: 1 },
   { label: 'Two', value: 2 }
 ]" />
 ```
 
-## Props
+### Props
 
 The props documented below have defaults set or are unique to this component, all typical HTML5 attributes are valid props. See Field for additional props.
 
 <api-table type=vue component="Toggle"/>
 
-## Validation
-### Validating Elements
+### Validation
+
+#### Validating Elements
 Every form element accepts a prop rules which takes an array of functions. These functions will be run in order until one returns an object. If all functions return true the field is considered valid.
 
 ```js
@@ -38,21 +39,20 @@ The function has one argument, the current value of the form element — and can
 
 <api-table type=vue component="InputAttributes"/>
 
-### Collecting Validation from wForm
+#### Collecting Validation from wForm
 The wForm component registers element descendants at any level, and provides the aggregate validation status.
 
 <api-table type=vue component="InputValidation"/>
 
-### Programmatic validation
+#### Programmatic validation
 The wField component can provide access to programmatic validation beyond what wForm's props can. For information on which methods are available, see the documentation on Field.
 
-```html
+```vue
 <w-field #control="{ form }">
   <button @click="submit(form)">Submit</button>
 </w-field>
 ```
 
-### Validation and required Form Elements
+#### Validation and required Form Elements
 If the form element is marked `required`, a special rule will be inserted before any user-defined rules.
 The `required` prop can accept a function that will be used as the required-rule.
-

--- a/docs/components/select/Example.vue
+++ b/docs/components/select/Example.vue
@@ -3,36 +3,38 @@
 </script>
 
 <template>
-  <h3>Standard with hint and disabled first option</h3>
-  <div class="component">
-    <w-select label="A label" hint="A hint" v-model="model" >
-      <option disabled selected value="">Pick something</option>
-      <option value="foo">Foo</option>
-      <option value="bar">Bar</option>
-    </w-select>
-  </div>
-  <h3>Optional</h3>
-  <div class="component">
-    <w-select optional v-model="selectModel" label="A useful and informative label">
-      <option selected value="">Pick something</option>
-      <option value="foo">Foo</option>
-      <option value="bar">Bar</option>
-    </w-select>
-  </div>
-  <h3>Disabled</h3>
-  <div class="component">
-    <w-select :disabled="true" v-model="selectModel" label="Disabled select">
-      <option selected value="">Pick something</option>
-      <option value="foo">Foo</option>
-      <option value="bar">Bar</option>
-    </w-select>
-  </div>
-  <h3>Invalid</h3>
-  <div class="component">
-    <w-select required invalid v-model="selectModel" label="Invalid">
-      <option selected value="">Pick something</option>
-      <option value="foo">Foo</option>
-      <option value="bar">Bar</option>
-    </w-select>
+  <div class="component space-y-16">
+    <div>
+      <h3 class="h4">Standard with hint and disabled first option</h3>
+      <w-select label="A label" hint="A hint" v-model="model" >
+        <option disabled selected value="">Pick something</option>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </w-select>
+    </div>
+    <div>
+      <h3 class="h4">Optional</h3>
+      <w-select optional v-model="selectModel" label="A useful and informative label">
+        <option selected value="">Pick something</option>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </w-select>
+    </div>
+    <div>
+      <h3 class="h4">Disabled</h3>
+      <w-select :disabled="true" v-model="selectModel" label="Disabled select">
+        <option selected value="">Pick something</option>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </w-select>
+    </div>
+    <div>
+      <h3 class="h4">Invalid</h3>
+      <w-select required invalid v-model="selectModel" label="Invalid">
+        <option selected value="">Pick something</option>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </w-select>
+    </div>
   </div>
 </template>

--- a/docs/components/select/Example.vue
+++ b/docs/components/select/Example.vue
@@ -1,12 +1,18 @@
 <script setup>
   import { wSelect } from '@warp-ds/vue';
+  import { ref } from "vue";
+
+  const selectModel1 = ref('');
+  const selectModel2 = ref('');
+  const selectModel3 = ref('');
+  const selectModel4 = ref('');
 </script>
 
 <template>
   <div class="component space-y-16">
     <div>
       <h3 class="h4">Standard with hint and disabled first option</h3>
-      <w-select label="A label" hint="A hint" v-model="model" >
+      <w-select label="A label" hint="A hint" v-model="selectModel1" >
         <option disabled selected value="">Pick something</option>
         <option value="foo">Foo</option>
         <option value="bar">Bar</option>
@@ -14,7 +20,7 @@
     </div>
     <div>
       <h3 class="h4">Optional</h3>
-      <w-select optional v-model="selectModel" label="A useful and informative label">
+      <w-select optional v-model="selectModel2" label="A useful and informative label">
         <option selected value="">Pick something</option>
         <option value="foo">Foo</option>
         <option value="bar">Bar</option>
@@ -22,7 +28,7 @@
     </div>
     <div>
       <h3 class="h4">Disabled</h3>
-      <w-select :disabled="true" v-model="selectModel" label="Disabled select">
+      <w-select :disabled="true" v-model="selectModel3" label="Disabled select">
         <option selected value="">Pick something</option>
         <option value="foo">Foo</option>
         <option value="bar">Bar</option>
@@ -30,7 +36,7 @@
     </div>
     <div>
       <h3 class="h4">Invalid</h3>
-      <w-select required invalid v-model="selectModel" label="Invalid">
+      <w-select required invalid v-model="selectModel4" label="Invalid">
         <option selected value="">Pick something</option>
         <option value="foo">Foo</option>
         <option value="bar">Bar</option>

--- a/docs/components/select/index.md
+++ b/docs/components/select/index.md
@@ -17,12 +17,16 @@ A dropdown component for selecting a single value. Selects (sometimes known as "
 
 ## Usage
 
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
 ### Accessibility
 
 If a visible label isn't specified, an `aria-label` should be provided to the
 Select for accessibility. If the field is labeled by a separate element, an
 `aria-labelledby` prop should be provided using the id of the labeling element
 instead.
+
+<component-questions />
 
 ## Frameworks
 
@@ -32,7 +36,5 @@ instead.
   </template>
   <template #vue>
     <vue />
-  </template>
-  <template #elements>
   </template>
 </tabs-content>

--- a/docs/components/select/react.md
+++ b/docs/components/select/react.md
@@ -1,10 +1,10 @@
-## Import
+### Import
 
 ```js
 import { Select } from '@warp-ds/react';
 ```
 
-## React syntax
+### Syntax
 
 ```jsx example
 <Select label="Berries">
@@ -14,11 +14,11 @@ import { Select } from '@warp-ds/react';
 </Select>
 ```
 
-## Props
+### Props
 
 <api-table type=react component="Select" />
 
-## Value
+#### Value
 
 An initial, uncontrolled, value can be provided using the `defaultValue` prop.
 Alternatively, a controlled value can be provided using the `value` prop.
@@ -49,12 +49,12 @@ function Example() {
 }
 ```
 
-## Labeling
+#### Labelling
 
 A visual label should be provided for the Select using the `label` prop.
 
 
-### Optional
+#### Optional
 
 Add the `optional` prop to indicate that the select is not required.
 
@@ -66,7 +66,7 @@ Add the `optional` prop to indicate that the select is not required.
 </Select>
 ```
 
-## Hint text
+#### Hint text
 
 Selects can provide additional context with `hint` if the label and placeholder
 aren't enough. You can force the hint text to always display by setting the
@@ -80,7 +80,7 @@ aren't enough. You can force the hint text to always display by setting the
 </Select>
 ```
 
-## Validation
+### Validation
 
 Selects can communicate to the user whether the current value is invalid.
 Implement your own validation logic in your app and set the `invalid` prop to
@@ -97,7 +97,7 @@ error.
 </Select>
 ```
 
-## Disabled
+### Disabled
 
 Using disabled is considered an anti-pattern and is therefore not supported.
 There will ALWAYS be users who don't understand why an element is disabled, or

--- a/docs/components/select/react.md
+++ b/docs/components/select/react.md
@@ -100,6 +100,6 @@ error.
 ### Disabled
 
 Using disabled is considered an anti-pattern and is therefore not supported.
-There will ALWAYS be users who don't understand why an element is disabled, or
+There will always be users who don't understand why an element is disabled, or
 users who can't even see that it is disabled because of poor lighting conditions
 or other reasons. Please consider more informative alternatives.

--- a/docs/components/select/vue.md
+++ b/docs/components/select/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 ```js
@@ -11,24 +11,25 @@ app.use(Forms)
 import { wSelect } from '@warp-ds/vue'
 ```
 
-## Syntax
+### Syntax
 
-```html
+```vue
 <w-select v-model="model" label="A label">
   <option disabled selected value="">Pick something</option>
   <option value="foo">Foo</option>
 </w-select>
 ```
 
-## Props
+### Props
 All typical HTML5 attributes are valid props for select.
 
 Below are some additional props documented.
 
 <api-table type=vue component="Field"/>
 
-## Validation
-### Validating Elements
+### Validation
+
+#### Validating Elements
 Every form element accepts a prop rules which takes an array of functions. These functions will be run in order until one returns an object. If all functions return true the field is considered valid.
 
 ```js
@@ -39,21 +40,20 @@ The function has one argument, the current value of the form element — and can
 
 <api-table type=vue component="InputAttributes"/>
 
-### Collecting Validation from wForm
+#### Collecting Validation from wForm
 The wForm component registers element descendants at any level, and provides the aggregate validation status.
 
 <api-table type=vue component="InputValidation"/>
 
-### Programmatic validation
+#### Programmatic validation
 The wField component can provide access to programmatic validation beyond what wForm's props can. For information on which methods are available, see the documentation on Field.
 
-```html
+```vue
 <w-field #control="{ form }">
   <button @click="submit(form)">Submit</button>
 </w-field>
 ```
 
-### Validation and required Form Elements
+#### Validation and required Form Elements
 If the form element is marked `required`, a special rule will be inserted before any user-defined rules.
 The `required` prop can accept a function that will be used as the required-rule.
-

--- a/docs/components/slider/Example.vue
+++ b/docs/components/slider/Example.vue
@@ -10,27 +10,29 @@ const currentValueDisabled = ref(1_000_000);
 </script>
 
 <template>
-  <h3 class="font-bold">Enabled</h3>
-  <div class="component" :state="currentValueEnabled">
-    <p>{{ currentValueEnabled }}</p>
-    <w-slider
-      v-model="currentValueEnabled"
-      :min="minimum"
-      :max="maximum"
-      :step="1000"
-      label="a large number slider"
-    />
-  </div>
-  <h3 class="font-bold">Disabled</h3>
-  <div class="component" :state="currentValueDisabled">
-    <p>{{ currentValueDisabled }}</p>
-    <w-slider
-      disabled
-      v-model="currentValueDisabled"
-      :min="minimum"
-      :max="maximum"
-      :step="1000"
-      label="a large number slider"
-    />
+  <div class="component space-y-16">
+    <div>
+      <h3 class="h4">Enabled</h3>
+      <p>Current value: {{ currentValueEnabled }}</p>
+      <w-slider
+        v-model="currentValueEnabled"
+        :min="minimum"
+        :max="maximum"
+        :step="1000"
+        label="a large number slider"
+      />
+    </div>
+    <div>
+      <h3 class="h4">Disabled</h3>
+      <p>Current value: {{ currentValueDisabled }}</p>
+      <w-slider
+        disabled
+        v-model="currentValueDisabled"
+        :min="minimum"
+        :max="maximum"
+        :step="1000"
+        label="a large number slider"
+      />
+    </div>
   </div>
 </template>

--- a/docs/components/slider/index.md
+++ b/docs/components/slider/index.md
@@ -13,7 +13,7 @@ A slider is an input where the user selects a value from within a given range. T
 
 <theme-switcher />
 
-<slider-example></slider-example>
+<slider-example />
 
 ## Usage
 

--- a/docs/components/slider/index.md
+++ b/docs/components/slider/index.md
@@ -17,6 +17,8 @@ A slider is an input where the user selects a value from within a given range. T
 
 ## Usage
 
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
 ### Accessibility
 
 To be accessible, an `aria-label` prop should be provided to the slider. If the slider is labeled by a separate element, use the `labelledby` prop with the id of the labeling element instead.
@@ -24,6 +26,8 @@ To be accessible, an `aria-label` prop should be provided to the slider. If the 
 ### Events
 
 The slider accepts an `onChange` prop which is triggered whenever the value is changed by the user. Note that this value updates as the user is dragging.
+
+<component-questions />
 
 ## Frameworks
 
@@ -33,7 +37,5 @@ The slider accepts an `onChange` prop which is triggered whenever the value is c
   </template>
   <template #vue>
     <vue />
-  </template>
-  <template #elements>
   </template>
 </tabs-content>

--- a/docs/components/slider/react.md
+++ b/docs/components/slider/react.md
@@ -1,10 +1,8 @@
-## Import
+### Import
 
 ```js
 import { Slider } from '@warp-ds/react';
 ```
-
-## Visual options
 
 ### Examples
 
@@ -30,12 +28,12 @@ function Example() {
 
 #### Disabled
 
-```js
+```jsx
 <div>
   <Slider aria-label="Disabled slider" value={50} disabled />
 </div>
 ```
 
-## Props
+### Props
 
 <api-table type="react" component="Slider" />

--- a/docs/components/slider/vue.md
+++ b/docs/components/slider/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 
@@ -13,12 +13,10 @@ app.use(Slider);
 import { wSlider } from '@warp-ds/vue';
 ```
 
-## Visual options
-
 ### Examples
 
 #### Enabled
-```js
+```vue
 <script setup>
   import { ref } from 'vue';
   import { wSlider } from '@warp-ds/vue';
@@ -27,27 +25,25 @@ import { wSlider } from '@warp-ds/vue';
 </script>
 
 <template>
-  <div :state="currentValue">
-    <w-slider
-      v-model="currentValue"
-      :min="1000"
-      :max="10_000_000"
-      :step="1000"
-      label="slider"
-    />
-  </div>
+  <w-slider
+    v-model="currentValue"
+    :min="1000"
+    :max="10_000_000"
+    :step="1000"
+    label="slider"
+  />
 </template>
 ```
 
 #### Disabled
-```js
+```html
 <w-slider
   disabled
-  v-model="50"
+  v-model="currentValue"
   label="Disabled slider"
 />
 ```
 
-## Props
+### Props
 
 <api-table type="vue" component="Slider" />

--- a/docs/components/steps/Example.vue
+++ b/docs/components/steps/Example.vue
@@ -1,64 +1,70 @@
 <script setup>
-import { ref } from 'vue';
+import {computed, reactive, ref} from 'vue';
 import { wButton, wSteps, wStep } from '@warp-ds/vue';
+import DemoControls from "../../.vitepress/Controls.vue";
 
-const alignment = {
+const steps = [
+  { name: 'Step 1', desc: 'The first step' },
+  { name: 'Step 2', desc: 'The second step' },
+  { name: 'Step 3', desc: 'The last step' },
+];
+
+const currentStep = ref(0);
+
+const stepControlButtonText = computed(() => {
+    switch(currentStep.value) {
+      case steps.length:
+        return 'Start over';
+      case (steps.length - 1):
+        return 'Finish'
+      default:
+        return 'Next step';
+    }
+});
+
+const nextStep = () => {
+  if (++currentStep.value > steps.length) currentStep.value = 0;
+};
+
+const alignments = {
   vertical: 'Vertical',
   horizontal: 'Horizontal',
 };
 
-const position = {
+const positions = {
   left: 'Left',
   right: 'Right',
 };
 
-const currentStep = ref(1);
-const currentAlignment = ref(alignment.vertical);
-const currentPosition = ref(position.left);
+const useIsActive = (state) => (name) => state.active === name;
+const radio = true;
 
-const handleClick = () => {
-  if (currentStep.value < 4) currentStep.value += 1;
-  else currentStep.value = 1;
-};
+const alignmentState = reactive({ active: alignments.horizontal });
+const isActiveAlignment = useIsActive(alignmentState);
+const alignmentControls = Object.entries(alignments).map(([,name]) => ({ name, radio }));
+
+const positionState = reactive({ active: positions.left });
+const isActivePosition = useIsActive(positionState);
+const positionControls = Object.entries(positions).map(([,name]) => ({ name, radio }));
 </script>
 
 <template>
-  <div class="options">
-    <label v-for="[name, value] in Object.entries(alignment)" :key="name">
-      <input
-        type="radio"
-        :id="name"
-        :value="value"
-        v-model="currentAlignment"
-      />
-      <span>{{ value }}</span>
-    </label>
-  </div>
-  <div class="options">
-    <label v-for="[name, value] in Object.entries(position)" :key="name">
-      <input type="radio" :id="name" :value="value" v-model="currentPosition" />
-      <span>{{ value }}</span>
-    </label>
-  </div>
-  <div>
+  <div class="component">
     <w-steps
-      class="component"
-      :horizontal="currentAlignment === alignment.horizontal"
-      :right="currentPosition === position.right"
+      :horizontal="isActiveAlignment(alignments.horizontal)"
+      :right="isActivePosition(positions.right)"
+      class="mb-32"
     >
-      <w-step :active="currentStep === 1" :complete="currentStep > 1">
-        <p class="font-bold">Step 1</p>
-        <p>Describing text</p>
-      </w-step>
-      <w-step :active="currentStep === 2" :complete="currentStep > 2">
-        <p class="font-bold">Step 2</p>
-        <p>Describing text</p>
-      </w-step>
-      <w-step :active="currentStep === 3" :complete="currentStep > 3">
-        <p class="font-bold">Step 3</p>
-        <p>Describing text</p>
+      <w-step v-for="(step, stepIndex) in steps" :key="step.name" :active="currentStep === stepIndex" :complete="currentStep > stepIndex">
+        <strong>{{ step.name }}</strong>
+        <p>{{ step.desc }}</p>
       </w-step>
     </w-steps>
-    <w-button primary v-on:click="handleClick">Next step</w-button>
+
+    <demo-controls x class="flex items-center">
+      <demo-control label="Alignment" :controls="alignmentControls" :state="alignmentState" />
+      <demo-control v-if="isActiveAlignment(alignments.vertical)" label="Position" :controls="positionControls" :state="positionState" />
+      <w-button primary @click="nextStep" class="last:mb-32 last-child:mb-32 mb-32 last:ml-auto!">{{ stepControlButtonText }}</w-button>
+    </demo-controls>
   </div>
 </template>

--- a/docs/components/steps/index.md
+++ b/docs/components/steps/index.md
@@ -13,7 +13,13 @@ The steps component is built to handle user journeys, making it clear to the end
 
 <theme-switcher />
 
-<steps-example></steps-example>
+<steps-example />
+
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
 
 ## Frameworks
 
@@ -23,7 +29,5 @@ The steps component is built to handle user journeys, making it clear to the end
   </template>
   <template #vue>
     <vue />
-  </template>
-  <template #elements>
   </template>
 </tabs-content>

--- a/docs/components/steps/react.md
+++ b/docs/components/steps/react.md
@@ -1,10 +1,10 @@
-## Import
+### Import
 
 ```js
 import { Steps, Step } from '@warp-ds/react';
 ```
 
-## Syntax
+### Syntax
 
 ```js
 function Example() {
@@ -29,7 +29,7 @@ function Example() {
 
 **Note** the `active` and `completed` properties on the `<Step>` component. You have to conditionally set the truthiness of these properties depending on where in the process the user is. See interactive example below.
 
-### Interactive usage
+#### Interactive usage
 
 ```js
 function Example() {
@@ -80,12 +80,12 @@ function Example() {
 
 **Note** the `horizontal` and `right` properties on the `<Steps>` component. These choose the direction and alignment of the steps.
 
-## Props
+### Props
 
-### Steps
+#### Steps
 
 <api-table type="react" component="Steps" />
 
-### Step
+#### Step
 
 <api-table type="react" component="Step" />

--- a/docs/components/steps/vue.md
+++ b/docs/components/steps/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 
@@ -13,62 +13,63 @@ app.use(Steps);
 import { wSteps, wStep } from '@warp-ds/vue';
 ```
 
-## Syntax
+### Syntax
 
-```js
+```vue
 <w-steps>
-  <w-step complete>
-    <h3>Step 1</h3>
-  </w-step>
-  <w-step active>
-    <h3>Step 2</h3>
-  </w-step>
-  <w-step>
-    <h3>Step 3</h3>
-  </w-step>
+  <w-step complete>Step 1</w-step>
+  <w-step active>Step 2</w-step>
+  <w-step>Step 3</w-step>
 </w-steps>
 ```
 
-### Interactive usage
+#### Interactive usage
 
-```js
+```vue
 <script setup>
-import { ref } from 'vue';
+import { computed, reactive, ref } from 'vue';
 import { wButton, wSteps, wStep } from '@warp-ds/vue';
 
-const currentStep = ref(1);
+const steps = [
+  { name: 'Step 1', desc: 'The first step' },
+  { name: 'Step 2', desc: 'The second step' },
+  { name: 'Step 3', desc: 'The last step' },
+];
 
-const handleClick = () => {
-  if (currentStep.value < 4) currentStep.value += 1;
-  else currentStep.value = 1;
+const currentStep = ref(0);
+
+const stepControlButtonText = computed(() => {
+  switch(currentStep.value) {
+    case steps.length:
+      return 'Start over';
+    case (steps.length - 1):
+      return 'Finish'
+    default:
+      return 'Next step';
+  }
+});
+
+const nextStep = () => {
+  if (++currentStep.value > steps.length) currentStep.value = 0;
 };
 </script>
-
 <template>
-  <w-steps>
-    <w-step :active="currentStep === 1" :complete="currentStep > 1">
-      <p class="font-bold">Step 1</p>
-      <p>Describing text</p>
-    </w-step>
-    <w-step :active="currentStep === 2" :complete="currentStep > 2">
-      <p class="font-bold">Step 2</p>
-      <p>Describing text</p>
-    </w-step>
-    <w-step :active="currentStep === 3" :complete="currentStep > 3">
-      <p class="font-bold">Step 3</p>
-      <p>Describing text</p>
+  <w-steps horizontal>
+    <w-step v-for="(step, stepIndex) in steps" :key="step.name" :active="currentStep === stepIndex" :complete="currentStep > stepIndex">
+      <strong>{{ step.name }}</strong>
+      <p>{{ step.desc }}</p>
     </w-step>
   </w-steps>
-  <w-button primary v-on:click="handleClick">Next step</w-button>
+  <w-button @click="nextStep">{{ stepControlButtonText }}</w-button>
 </template>
 ```
 
-## Props
+### Props
 
-### Steps
+#### Steps
 
 <api-table type="vue" component="Steps" />
 
-### Step
+#### Step
 
 <api-table type="vue" component="Step" />

--- a/docs/components/switch/Example.vue
+++ b/docs/components/switch/Example.vue
@@ -6,7 +6,9 @@
 </script>
 
 <template>
-  <w-field label="Switch it" #default="{ labelFor }">
-    <w-switch v-model="toggle" :id="labelFor" />
-  </w-field>
+  <div class="component">
+    <w-field label="Switch it" #default="{ labelFor }">
+      <w-switch v-model="toggle" :id="labelFor" />
+    </w-field>
+  </div>
 </template>

--- a/docs/components/switch/index.md
+++ b/docs/components/switch/index.md
@@ -13,6 +13,14 @@ The Switch component allows users to toggle between validity for a condition.
 
 <switch-example />
 
+## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
+<component-questions />
+
+## Frameworks
+
 <tabs-content> 
   <template #react>
     <react />

--- a/docs/components/switch/react.md
+++ b/docs/components/switch/react.md
@@ -1,19 +1,17 @@
-## React Implementation
-
 ### Import
 
 ```js
 import { Switch } from "@warp-ds/react";
 ```
 
-### Usage
+### Syntax
 
 ```js
-    <Switch
-        value={value}
-        onClick={() => setValue(!value)}
-        aria-label="Toggle switch"
-    />
+  <Switch
+    value={value}
+    onClick={() => setValue(!value)}
+    aria-label="Toggle switch"
+  />
 ```
 
 ### Accessibility
@@ -24,7 +22,6 @@ The Switch needs either `aria-label` or `aria-labelledby` to be accessible to sc
 
 There is no visual styling to a disabled button.
 It is recommended to display a message to the user, for example a modal or toast, stating why the user cannot toggle the switch.
-
 
 ### Props
 

--- a/docs/components/switch/vue.md
+++ b/docs/components/switch/vue.md
@@ -1,5 +1,3 @@
-## Vue implementation
-
 ### Import
 
 #### Use in entire app
@@ -15,9 +13,9 @@ app.use(Switch);
 import { wSwitch } from "@warp-ds/vue";
 ```
 
-### Usage
+### Syntax
 
-```js
+```vue
 <w-switch v-model="model" />
 ```
 

--- a/docs/components/tabs/Example.vue
+++ b/docs/components/tabs/Example.vue
@@ -11,34 +11,32 @@ const Stars = {
     }),
 };
 
-const model = ref('one');
+const selectedTab = ref('one');
 </script>
 
 <template>
   <div class="component">
-    <token :state="[model]">
-      <w-tabs v-model="model">
-        <w-tab label="Tab 1" name="one">
-          <stars />
-        </w-tab>
-        <w-tab label="Tab 2" name="two">
-          <stars />
-        </w-tab>
-        <w-tab label="Tab 3" name="three">
-          <stars />
-        </w-tab>
-      </w-tabs>
-      <div>
-        <w-tab-panel name="one" v-if="model === 'one'">
-          <p class="mb-0">First tab content</p>
-        </w-tab-panel>
-        <w-tab-panel name="two" v-if="model === 'two'">
-          <p class="mb-0">Second tab content</p>
-        </w-tab-panel>
-        <w-tab-panel name="three" v-if="model === 'three'">
-          <p class="mb-0">Third tab content</p>
-          </w-tab-panel>
-      </div>
-    </token>
+    <w-tabs v-model="selectedTab">
+      <w-tab label="Tab 1" name="one">
+        <stars />
+      </w-tab>
+      <w-tab label="Tab 2" name="two">
+        <stars />
+      </w-tab>
+      <w-tab label="Tab 3" name="three">
+        <stars />
+      </w-tab>
+    </w-tabs>
+    <div>
+      <w-tab-panel name="one" v-if="selectedTab === 'one'">
+        First tab content
+      </w-tab-panel>
+      <w-tab-panel name="two" v-if="selectedTab === 'two'">
+        Second tab content
+      </w-tab-panel>
+      <w-tab-panel name="three" v-if="selectedTab === 'three'">
+        Third tab content
+      </w-tab-panel>
+    </div>
   </div>
 </template>

--- a/docs/components/tabs/index.md
+++ b/docs/components/tabs/index.md
@@ -11,12 +11,17 @@ import React from './react.md';
 
 <theme-switcher />
 
-<tabs-example></tabs-example>
+<tabs-example />
 
 ## Usage
+
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
 ### Accessibility
 
 Focus management and ARIA attributes are handled automatically.
+
+<component-questions />
 
 ## Frameworks
 
@@ -26,7 +31,5 @@ Focus management and ARIA attributes are handled automatically.
   </template>
   <template #vue>
     <vue />
-  </template>
-  <template #elements>
   </template>
 </tabs-content>

--- a/docs/components/tabs/react.md
+++ b/docs/components/tabs/react.md
@@ -1,16 +1,15 @@
-## Import
+### Import
 
 ```js
 import { Tab, Tabs, TabPanel } from '@warp-ds/react';
 ```
-## Visual options
 
-### Examples
+### Syntax
 
 #### Default
 The following example demonstrates how the Tab, Tabs, and TabPanel components can be used to switch between panels.
 
-```js
+```jsx
 <>
   <Tabs>
     <Tab label="Tab 1" name="one" isActive />
@@ -24,6 +23,7 @@ The following example demonstrates how the Tab, Tabs, and TabPanel components ca
   </div>
 </>
 ```
+
 #### Tabs with left icons
 
 ```js
@@ -97,7 +97,7 @@ function Example() {
 }
 ```
 
-## Technical details
+### Technical details
 You can set the active tab in one of two ways:
 
 1. By passing the name of the active Tab to the Tabs component using the active attribute.
@@ -107,8 +107,16 @@ It is important that all children of Tabs are Tab components.
 
 Note that name attributes will be used to generate id attributes (prefixed with warp-tab- and warp-tabpanel-), and therefore they must be unique throughout the entire DOM. This is because aria-controls and aria-labelledby rely on id attributes, and they are required for the tabs to be ARIA compliant.
 
-## Props
-### Tabs
+### Props
+
+#### Tabs
+
 <api-table type="react" component="Tabs" />
-### Tab
+
+#### Tab
+
 <api-table type="react" component="Tab" />
+
+#### TabPanel
+
+<api-table type="react" component="TabPanel" />

--- a/docs/components/tabs/vue.md
+++ b/docs/components/tabs/vue.md
@@ -1,6 +1,7 @@
-## Import
+### Import
 
 > Use in entire app
+
 ```js
 import { Tabs } from '@warp-ds/vue';
 app.use(Tabs);
@@ -12,14 +13,13 @@ app.use(Tabs);
 import { wTabs } from '@warp-ds/vue';
 ```
 
-## Visual options
+### Syntax
 
-### Examples
 The following examples demonstrates how the `Tab`, `Tabs`, and `TabPanel` components can be used to switch between panels.
 
 #### Default
 
-```js
+```vue
 <w-tabs>
   <w-tab label="Tab 1" name="one" isActive />
   <w-tab label="Tab 2" name="two" />
@@ -28,69 +28,68 @@ The following examples demonstrates how the `Tab`, `Tabs`, and `TabPanel` compon
 ```
 #### Tabs with panel content
 
-```js
-<token :state="[model]">
-  <w-tabs v-model="model">
-    <w-tab label="Tab 1" name="one" />
-    <w-tab label="Tab 2" name="two" />
-    <w-tab label="Tab 3" name="three" />
-  </w-tabs>
-  <div>
-    <w-tab-panel name="one" v-if="model === 'one'">
-      <p>First tab content</p>
-    </w-tab-panel>
-    <w-tab-panel name="two" v-if="model === 'two'">
-      <p>Second tab content</p>
-      </w-tab-panel>
-    <w-tab-panel name="three" v-if="model === 'three'">
-      <p>Third tab content</p>
-    </w-tab-panel>
-  </div>
-</token>
+```vue
+<w-tabs v-model="selectedTab">
+  <w-tab label="Tab 1" name="one" />
+  <w-tab label="Tab 2" name="two" />
+  <w-tab label="Tab 3" name="three" />
+</w-tabs>
+<div>
+  <w-tab-panel name="one" v-if="selectedTab === 'one'">
+    First tab content
+  </w-tab-panel>
+  <w-tab-panel name="two" v-if="selectedTab === 'two'">
+    Second tab content
+  </w-tab-panel>
+  <w-tab-panel name="three" v-if="selectedTab === 'three'">
+    Third tab content
+  </w-tab-panel>
+</div>
 ```
 #### Tabs with icons and panel content
 
-```js
+```vue
 <script setup>
 import { wTabs, wTab, wTabPanel } from '@warp-ds/vue';
 import { ref } from 'vue';
 import { iconSvg } from '/icons';
 
-const model = ref("first");
+const selectedTab = ref("first");
 </script>
 
 <template>
-  <token :state="[model]">
-    <w-tabs v-model="model">
-      <w-tab label="Tab 1" name="one">
-        <iconSvg />
-      </w-tab>
-      <w-tab label="Tab 2" name="two">
-        <iconSvg />
-      </w-tab>
-      <w-tab label="Tab 3" name="three">
-        <iconSvg />
-      </w-tab>
-    </w-tabs>
-    <div>
-      <w-tab-panel name="one" v-if="model === 'one'">
-        <p class="mb-0">First tab content</p>
-        </w-tab-panel>
-      <w-tab-panel name="two" v-if="model === 'two'">
-        <p class="mb-0">Second tab content</p></w-tab-panel>
-      <w-tab-panel name="three" v-if="model === 'three'">
-        <p class="mb-0">Third tab content</p>
-        </w-tab-panel>
-    </div>
-  </token>
+  <w-tabs v-model="selectedTab">
+    <w-tab label="Tab 1" name="one">
+      <iconSvg />
+    </w-tab>
+    <w-tab label="Tab 2" name="two">
+      <iconSvg />
+    </w-tab>
+    <w-tab label="Tab 3" name="three">
+      <iconSvg />
+    </w-tab>
+  </w-tabs>
+  <div>
+    <w-tab-panel name="one" v-if="selectedTab === 'one'">
+      First tab content
+    </w-tab-panel>
+    <w-tab-panel name="two" v-if="selectedTab === 'two'">
+      Second tab content
+    </w-tab-panel>
+    <w-tab-panel name="three" v-if="selectedTab === 'three'">
+      Third tab content
+    </w-tab-panel>
+  </div>
 </template>
 ```
 
+### Props
 
-## Props
-
-### Tabs
+#### Tabs
 <api-table type="vue" component="Tabs" />
 
-### Tab
+#### Tab
 <api-table type="vue" component="Tab" />
+
+#### TabPanel
+<api-table type="vue" component="TabPanel" />

--- a/docs/components/textarea/Example.vue
+++ b/docs/components/textarea/Example.vue
@@ -6,24 +6,26 @@
 </script>
 
 <template>
-  <h3>Standard with hint</h3>
-  <div class="component">
-    <w-textarea v-model="model" label="A label" hint="A hint" />
-  </div>
-  <h3>Optional</h3>
-  <div class="component">
-    <w-textarea v-model="model" label="A label" optional />
-  </div>
-  <h3>Disabled</h3>
-  <div class="component">
-    <w-textarea label="A label" disabled />
-  </div>
-  <h3>Read Only</h3>
-  <div class="component">
-    <w-textarea label="A label" value="This is a readOnly textarea" readOnly />
-  </div>
-  <h3>Invalid</h3>
-  <div class="component">
-    <w-textarea label="A label" invalid required />
+  <div class="component space-y-16">
+    <div>
+      <h3 class="h4">Standard with hint</h3>
+      <w-textarea v-model="model" label="A label" hint="A hint" />
+    </div>
+    <div>
+      <h3 class="h4">Optional</h3>
+      <w-textarea v-model="model" label="A label" optional />
+    </div>
+    <div>
+      <h3 class="h4">Disabled</h3>
+      <w-textarea label="A label" disabled />
+    </div>
+    <div>
+      <h3 class="h4">Read Only</h3>
+      <w-textarea label="A label" value="This is a readOnly textarea" readOnly />
+    </div>
+    <div>
+      <h3 class="h4">Invalid</h3>
+      <w-textarea label="A label" invalid required />
+    </div>
   </div>
 </template>

--- a/docs/components/textarea/Example.vue
+++ b/docs/components/textarea/Example.vue
@@ -3,6 +3,7 @@
   import { ref } from 'vue';
 
   const model = ref('');
+  const readOnlyText = 'This is a readOnly textarea';
 </script>
 
 <template>
@@ -21,7 +22,7 @@
     </div>
     <div>
       <h3 class="h4">Read Only</h3>
-      <w-textarea label="A label" value="This is a readOnly textarea" readOnly />
+      <w-textarea label="A label" v-model="readOnlyText" readOnly />
     </div>
     <div>
       <h3 class="h4">Invalid</h3>

--- a/docs/components/textarea/index.md
+++ b/docs/components/textarea/index.md
@@ -17,10 +17,14 @@ A multiline text input component.
 
 ## Usage
 
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
 ### Accessibility
 
 If a visible label isn't specified, an `aria-label` must be provided to the Text Area for accessibility.
 If the field is labeled by a separate element, an `aria-labelledby` prop must be provided using the id of the labeling element instead.
+
+<component-questions />
 
 ## Frameworks
 
@@ -30,7 +34,5 @@ If the field is labeled by a separate element, an `aria-labelledby` prop must be
   </template>
   <template #vue>
     <vue />
-  </template>
-  <template #elements>
   </template>
 </tabs-content>

--- a/docs/components/textarea/react.md
+++ b/docs/components/textarea/react.md
@@ -1,23 +1,22 @@
-## Import
+### Import
 
 ```js
 import { TextArea } from '@warp-ds/react';
 ```
 
-## Syntax
+### Syntax
 
-```js
+```jsx
 <TextArea label="Description" />
 ```
 
-## Props
+### Props
 
 <api-table type=react component="TextArea" />
 
-## Value
+#### Value
 
 A TextArea's value is empty by default, but an initial, uncontrolled, value can be provided using the `defaultValue` prop. Alternatively, a controlled value can be provided using the `value` prop.
-
 
 ```js
 function Example() {
@@ -37,64 +36,64 @@ function Example() {
 }
 ```
 
-## Labeling
+#### Labeling
 
 A visual label should be provided for the TextArea using the `label` prop.
 
-### Optional
+#### Optional
 
 Add the `optional` prop to indicate that the textarea is not required.
 
-```js
+```jsx
 <TextArea label="Description" optional />
 ```
 
-## Help text
+#### Help text
 
 TextAreas can provide additional context with `helpText` if the label and placeholder aren't enough.
 
-```js
+```jsx
 <TextArea label="Description" helpText="Maximum 200 characters" />
 ```
 
-## Validation
+### Validation
 
 TextAreas can communicate to the user whether the current value is invalid.
 Implement your own validation logic in your app and set the `invalid` prop to display it as invalid.
 
 `invalid` is often paired with `helpText` to provide feedback to the user about the error.
 
-```js
+```jsx
 <TextArea label="Description" invalid helpText="Maximum 200 characters" />
 ```
 
-## Visual options
+### Visual options
 
-### Placeholder
+#### Placeholder
 
-```js
+```jsx
 <TextArea label="Description" placeholder="Lorem ipsum dolor sit amet" />
 ```
 
 Placeholder text can be used to describe the expected value or formatting for the TextArea. Placeholder text will only appear when the TextArea is empty, and should not be used as a substitute for labeling the component with a visible label.
 
-### Disabled
+#### Disabled
 
 Keep in mind that using disabled in its current form is an anti-pattern. There will ALWAYS be users who don't understand why an element is disabled, or users who can't even see that it is disabled because of poor lighting conditions or other reasons. Please consider more informative alternatives before choosing to use disabled on an element.
 
-```js
+```jsx
 <div className="flex flex-col y-space-32">
   <TextArea label="Description" disabled value="Lorem ipsum dolor sit amet" />
   <TextArea label="Description" disabled />
 </div>
 ```
 
-### Read only
+#### Read only
 
 The `readOnly` boolean prop makes the TextArea's text content immutable. Unlike `disabled` the TextArea remains focusable and the contents can still be copied. See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)
  for more information.
 
-```js
+```jsx
 <div className="flex flex-col y-space-32">
   <TextArea
     label="Description"
@@ -105,18 +104,17 @@ The `readOnly` boolean prop makes the TextArea's text content immutable. Unlike 
 </div>
 ```
 
-
-### Height (text rows)
+#### Height (text rows)
 
 The minimumRows prop sets the minimum number of text rows the TextArea should show.
 
-```js
+```jsx
 <TextArea label="Description" minimumRows={3} />
 ```
 
 The `maximumRows` prop sets the maximum number of text rows the TextArea should show.
 
-```js
+```jsx
 <TextArea
   label="Description"
   maximumRows={3}

--- a/docs/components/textarea/react.md
+++ b/docs/components/textarea/react.md
@@ -79,7 +79,7 @@ Placeholder text can be used to describe the expected value or formatting for th
 
 #### Disabled
 
-Keep in mind that using disabled in its current form is an anti-pattern. There will ALWAYS be users who don't understand why an element is disabled, or users who can't even see that it is disabled because of poor lighting conditions or other reasons. Please consider more informative alternatives before choosing to use disabled on an element.
+Keep in mind that using disabled in its current form is an anti-pattern. There will always be users who don't understand why an element is disabled, or users who can't even see that it is disabled because of poor lighting conditions or other reasons. Please consider more informative alternatives before choosing to use disabled on an element.
 
 ```jsx
 <div className="flex flex-col y-space-32">

--- a/docs/components/textarea/vue.md
+++ b/docs/components/textarea/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 
@@ -13,13 +13,13 @@ app.use(Forms)
 import { wTextarea } from '@warp-ds/vue'
 ```
 
-## Syntax
+### Syntax
 
-```html
+```vue
 <w-textarea label="A label" hint="A hint" v-model="model" />
 ```
 
-## Props
+### Props
 
 All typical HTML5 attributes are valid props for textarea.
 
@@ -27,9 +27,9 @@ Below are some additional props documented.
 
 <api-table type=vue component="Field"/>
 
-## Validation
+### Validation
 
-### Validating Elements
+#### Validating Elements
 
 Every form element accepts a prop `rules` which takes an array of functions. These functions will be run in order until one returns an object. If all functions return `true` the field is considered valid.
 
@@ -41,13 +41,13 @@ The function has one argument, the current value of the form element — and can
 
 <api-table type=vue component="InputAttributes"/>
 
-### Collecting Validation with wForm
+#### Collecting Validation with wForm
 
 The `wForm` component registers element descendants at any level, and provides the aggregate validation status.
 
 <api-table type=vue component="InputValidation"/>
 
-### Programmatic validation
+#### Programmatic validation
 
 The wField component can provide access to programmatic validation beyond what wForm's props can. For information on which methods are available, see the documentation on Field.
 
@@ -57,7 +57,7 @@ The wField component can provide access to programmatic validation beyond what w
 </w-field>
 ```
 
-### Validation and required Form Elements
+#### Validation and required Form Elements
 
 If the form element is marked required, a special rule will be inserted before any user-defined rules.
 

--- a/docs/components/textfield/Example.vue
+++ b/docs/components/textfield/Example.vue
@@ -1,43 +1,44 @@
 <script setup>
-  import { ref } from 'vue'
-  import { wTextfield, wAffix } from '@warp-ds/vue';
+import { ref } from 'vue'
+import { wTextfield, wAffix } from '@warp-ds/vue';
 
-  const inputModel = ref('');
+const inputModel = ref('');
 
-  const handleClear = () => {
-    inputModel.value = '';
-  }
-
+const handleClear = () => {
+  inputModel.value = '';
+}
 </script>
 
 <template>
-  <h3>Standard with hint</h3>
-  <div class="component">
-    <w-textfield v-model="inputModel" label="A label" hint="A hint" />
-  </div>
-  <h3>Optional with placeholder</h3>
-  <div class="component">
-    <w-textfield v-model="inputModel" label="A label" placeholder="This is a placeholder" optional />
-  </div>
-  <h3>Disabled</h3>
-  <div class="component">
-    <w-textfield label="A label" disabled />
-  </div>
-  <h3>Read Only</h3>
-  <div class="component">
-    <w-textfield label="A label" value="This is a readOnly textfield" readOnly />
-  </div>
-  <h3>Invalid</h3>
-  <div class="component">
-    <w-textfield label="A label" #suffix invalid required v-model="inputModel">
-      <w-affix suffix clear @click="handleClear" />
-    </w-textfield>
-  </div>
-  <h3>Suffix + Prefix</h3>
-  <div class="component">
-    <w-textfield label="A label" #prefix #suffix v-model="inputModel">
-      <w-affix suffix clear @click="handleClear" />
-      <w-affix prefix label="kr" />
-    </w-textfield>
+  <div class="component space-y-16">
+    <div>
+      <h3 class="h4">Standard with hint</h3>
+      <w-textfield v-model="inputModel" label="A label" hint="A hint" />
+    </div>
+    <div>
+      <h3 class="h4">Optional with placeholder</h3>
+      <w-textfield v-model="inputModel" label="A label" placeholder="This is a placeholder" optional />
+    </div>
+    <div>
+      <h3 class="h4">Disabled</h3>
+      <w-textfield label="A label" disabled />
+    </div>
+    <div>
+      <h3 class="h4">Read Only</h3>
+      <w-textfield label="A label" value="This is a readOnly textfield" readOnly />
+    </div>
+    <div>
+      <h3 class="h4">Invalid</h3>
+      <w-textfield label="A label" #suffix invalid required v-model="inputModel">
+        <w-affix suffix clear @click="handleClear" />
+      </w-textfield>
+    </div>
+    <div>
+      <h3 class="h4">Suffix + Prefix</h3>
+      <w-textfield label="A label" #prefix #suffix v-model="inputModel">
+        <w-affix suffix clear @click="handleClear" />
+        <w-affix prefix label="kr" />
+      </w-textfield>
+    </div>
   </div>
 </template>

--- a/docs/components/textfield/elements.md
+++ b/docs/components/textfield/elements.md
@@ -21,7 +21,7 @@ substitute for labeling the element with a visible label.
 ```
 
 ### Disabled
-Keep in mind that using disabled in its current form is an anti-pattern. There will ALWAYS
+Keep in mind that using disabled in its current form is an anti-pattern. There will always
 be users who don't understand why an element is disabled, or users who can't even see that
 it is disabled because of poor lighting conditions or other reasons. Please consider more
 informative alternatives before choosing to use disabled on an element.

--- a/docs/components/textfield/index.md
+++ b/docs/components/textfield/index.md
@@ -18,10 +18,14 @@ A single-line text input component.
 
 ## Usage
 
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
 ### Accessibility
 
 If a visible label isn't specified, an `aria-label` must be provided to the Text Field for accessibility.
 If the field is labeled by a separate element, an `aria-labelledby` prop must be provided using the id of the labeling element instead.
+
+<component-questions />
 
 ## Frameworks
 

--- a/docs/components/textfield/index.md
+++ b/docs/components/textfield/index.md
@@ -18,7 +18,7 @@ A single-line text input component.
 
 ## Usage
 
-<component-design-guidelines name="Warp - Components / Text Area" link="https://www.figma.com/file/nkiRpuVu6XRfvY96BA80H8/Components-overview?type=design&node-id=377-23909&mode=design" />
+<component-design-guidelines name="Warp - Components / Input" link="https://www.figma.com/file/nkiRpuVu6XRfvY96BA80H8/Components-overview?type=design&node-id=162-3118&mode=design&t=BeQTJcCWRTnsK9fC-0" />
 
 ### Accessibility
 

--- a/docs/components/textfield/react.md
+++ b/docs/components/textfield/react.md
@@ -1,20 +1,20 @@
-## Import
+### Import
 
 ```js
 import { TextField } from '@warp-ds/react';
 ```
 
-## Syntax
+### Syntax
 
-```js
+```jsx
 <TextField label="Name" />
 ```
 
-## Props
+### Props
 
 <api-table type=react component="TextField" />
 
-## Value
+#### Value
 
 A TextField's value is empty by default, but an initial, uncontrolled, value can be provided using the `defaultValue` prop. Alternatively, a controlled value can be provided using the `value` prop.
 
@@ -36,60 +36,61 @@ function Example() {
 }
 ```
 
-## Labeling
+#### Labeling
 
 A visual label should be provided for the TextField using the `label` prop.
 
-### Optional
+#### Optional
 
 Add the `optional` prop to indicate that the textfield is not required.
 
-```js
+```jsx
 <TextField label="Telefonnummer" optional />
 ```
-## Help text
+
+#### Help text
 
 TextFields can provide additional context with `helpText` if the label and placeholder aren't enough.
 
-```js
+```jsx
 <TextField
   label="Telefonnummer"
   helpText="Vil kun brukes til brukerverifisering"
 />
 ```
 
-## Validation
+### Validation
 
 TextFields can communicate to the user whether the current value is invalid. Implement your own validation logic in your app and set the `invalid` prop to display it as invalid.
 
 `invalid` is often paired with `helpText` to provide feedback to the user about the error.
 
-```js
+```jsx
 <TextField label="Email" invalid helpText="Ugyldig e-post" />
 ```
 
-## Visual options
+### Visual options
 
-### Placeholder
+#### Placeholder
 
-```js
+```jsx
 <TextField label="E-post" placeholder="puse@finn.no" />
 ```
 
 Placeholder text can be used to describe the expected value or formatting for the TextField. Placeholder text will only appear when the TextField is empty, and should not be used as a substitute for labeling the component with a visible label.
 
-### Disabled
+#### Disabled
 
 Keep in mind that using disabled in its current form is an anti-pattern. There will ALWAYS be users who don't understand why an element is disabled, or users who can't even see that it is disabled because of poor lighting conditions or other reasons. Please consider more informative alternatives before choosing to use disabled on an element.
 
-```js
+```jsx
 <div className="flex flex-col space-y-32">
   <TextField label="E-post" disabled value="puse@finn.no" />
   <TextField label="E-post" disabled />
 </div>
 ```
 
-### Affix
+#### Affix
 
 If you wish to use an affix you must first import the Affix component.
 
@@ -99,33 +100,33 @@ import { Affix } from '@warp-ds/react';
 
 Then you include it as a child of TextField component and pass the appropiate props (see bottom of this page for types)
 
-```js
+```jsx
 <TextField label="Price" placeholder="1 000 000">
   <Affix suffix label="kr" />
 </TextField>
 ```
 
-```js
+```jsx
 <TextField label="Price" placeholder="1 000 000">
   <Affix prefix label="kr" />
 </TextField>
 ```
 
-```js
+```jsx
 <TextField>
   <Affix suffix clear onClick={() => alert('clear')} />
 </TextField>
 ```
 
-```js
+```jsx
 <TextField>
   <Affix suffix search onClick={() => alert('search')} />
 </TextField>
 ```
 
-## You can also use both a prefix and suffix
+You can also use both a prefix and suffix
 
-```js
+```jsx
 <TextField>
   <Affix prefix label="kr" />
   <Affix suffix search onClick={() => alert('search')} />
@@ -136,12 +137,12 @@ You cannot set the `type` of the Affix. `type` of the button rendered as `Affix`
 
 <api-table type=react component="Affix" />
 
-### Read only
+#### Read only
 
 The readOnly boolean prop makes the TextField's text content immutable. Unlike disabled the TextField remains focusable and the contents can still be copied. See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)
  for more information.
 
-```js
+```jsx
 <div className="flex flex-col space-y-32">
   <TextField label="E-post" readOnly value="puse@finn.no" />
   <TextField label="E-post" readOnly />

--- a/docs/components/textfield/react.md
+++ b/docs/components/textfield/react.md
@@ -81,7 +81,7 @@ Placeholder text can be used to describe the expected value or formatting for th
 
 #### Disabled
 
-Keep in mind that using disabled in its current form is an anti-pattern. There will ALWAYS be users who don't understand why an element is disabled, or users who can't even see that it is disabled because of poor lighting conditions or other reasons. Please consider more informative alternatives before choosing to use disabled on an element.
+Keep in mind that using disabled in its current form is an anti-pattern. There will always be users who don't understand why an element is disabled, or users who can't even see that it is disabled because of poor lighting conditions or other reasons. Please consider more informative alternatives before choosing to use disabled on an element.
 
 ```jsx
 <div className="flex flex-col space-y-32">

--- a/docs/components/textfield/vue.md
+++ b/docs/components/textfield/vue.md
@@ -1,4 +1,4 @@
-## Import
+### Import
 
 > Use in entire app
 
@@ -13,19 +13,19 @@ app.use(Forms)
 import { wTextfield } from '@warp-ds/vue'
 ```
 
-## Syntax
+### Syntax
 
 ```html
 <w-textfield label="A label" hint="A hint" v-model="model" />
 ```
 
-## Props
+### Props
 
 The props documented below have defaults set or are unique to this component, all typical HTML5 attributes are valid props.
 
 <api-table type=vue component="TextField"/>
 
-### Masking
+#### Masking
 
 To use input masking, first provide the default export from the `cleave.js` package as shown below. Once you've done that, any [options](https://github.com/nosir/cleave.js/blob/master/doc/options.md) from Cleave are valid options on the mask prop.
 
@@ -44,9 +44,9 @@ export default {
 app.provide('Cleave', Cleave)
 ```
 
-## Validation
+### Validation
 
-### Validating Elements
+#### Validating Elements
 
 Every form element accepts a prop rules which takes an array of functions. These functions will be run in order until one returns an object. If all functions return true the field is considered valid.
 
@@ -57,13 +57,13 @@ The function has one argument, the current value of the form element — and can
 
 <api-table type=vue component="InputAttributes"/>
 
-### Collecting Validation with wForm
+#### Collecting Validation with wForm
 
 The wForm component registers element descendants at any level, and provides the aggregate validation status.
 
 <api-table type=vue component="InputValidation"/>
 
-### Programmatic validation
+#### Programmatic validation
 
 The wField component can provide access to programmatic validation beyond what wForm's props can. For information on which methods are available, see the documentation on Field.
 
@@ -73,13 +73,13 @@ The wField component can provide access to programmatic validation beyond what w
 </w-field>
 ```
 
-### Validation and required Form Elements
+#### Validation and required Form Elements
 
 If the form element is marked required, a special rule will be inserted before any user-defined rules.
 
 The required prop can accept a function that will be used as the required-rule.
 
-## FIELD Syntax 
+### FIELD Syntax 
 
 ```html
 <w-field label="I can be anything!" hint="Isn't that neat?">

--- a/docs/components/toast/Example.vue
+++ b/docs/components/toast/Example.vue
@@ -1,18 +1,20 @@
 <template>
-  <h3>Success</h3>
-  <div class="component">
-    <img src="/toast_success.png" alt="toast success can close" width="200"/>
-  </div>
-  <h3>Warning</h3>
-  <div class="component">
-    <img src="/toast_warning.png" alt="toast success can close" width="200"/>
-  </div>
-  <h3>Error</h3>
-  <div class="component">
-    <img src="/toast_error.png" alt="toast success can close" width="200"/>
-  </div>
-  <h3>Success with close button</h3>
-  <div class="component">
-    <img src="/toast_success_close.png" alt="toast success can close" width="225"/>
+  <div class="component space-y-16">
+    <div>
+      <h3 class="h4">Success</h3>
+      <img src="/toast_success.png" alt="toast success can close" width="200"/>
+    </div>
+    <div>
+      <h3 class="h4">Warning</h3>
+      <img src="/toast_warning.png" alt="toast success can close" width="200"/>
+    </div>
+    <div>
+      <h3 class="h4">Error</h3>
+      <img src="/toast_error.png" alt="toast success can close" width="200"/>
+    </div>
+    <div>
+      <h3 class="h4">Success with close button</h3>
+      <img src="/toast_success_close.png" alt="toast success can close" width="225"/>
+    </div>
   </div>
 </template>

--- a/docs/components/toast/elements.md
+++ b/docs/components/toast/elements.md
@@ -1,4 +1,5 @@
-## Import 
+### Import 
+
 The toast is intended to be used programmatically. JavaScript APIs are provided to create, update and remove toasts from a page while managing things like placement on the page for you.
 
 Toast is a bit different from other packages in Warp Elements. You need to import functions from the package and call them as needed.
@@ -13,12 +14,11 @@ import from '@warp-ds/elements'
 
 Once you have imported the elements package, import the toast api package.
 
-
 ```js
 import { toast, removeToast, updateToast } from '@warp-ds/elements';
 ```
 
-## Syntax
+### Syntax
 You create a new toast by giving it a message:
 
 ```js
@@ -37,47 +37,47 @@ Update an existing toast by id:
 updateToast(id, { text: 'This is a toast' });
 ```
 
-## Visual options
+### Visual options
 
-### Success
+#### Success
 
 ```js
 toast('message goes here', { type: 'success' });
 ```
 
-### Warning
+#### Warning
 
 ```js
 toast('message goes here', { type: 'warning' });
 ```
 
-### Error
+#### Error
 
 ```js
 toast('message goes here', { type: 'error' });
 ```
 
-### Success with close button
+#### Success with close button
 WARNING! The close icon is designed to automatically close by default, and it is recommended to avoid adding the manual close function due to accessability reasons. If the toast absolutely must be dismissible, set the `canclose` property to `true`.
 
 ```js
 toast('message goes here', { type: 'success', canclose: true });
 ```
 
-## Options
+### Options
 
-### Auto removal with duration
+#### Auto removal with duration
 
 ```js
 toast('message goes here', { type: 'success', duration: 2500 });
 ```
 
-### Text content
+#### Text content
 
 ```js
 const id = toast('message goes here'); updateToast({ id, text: 'change the message' });
 ```
 
-## Props
+### Props
 
 <api-table type="elements" component="Toast" />

--- a/docs/components/toast/index.md
+++ b/docs/components/toast/index.md
@@ -10,7 +10,7 @@ Toasts display small snippets of information to the user and then disappear afte
 
 ## Example
 
-<toast-example></toast-example>
+<toast-example />
 
 ## Usage
 

--- a/docs/components/toast/index.md
+++ b/docs/components/toast/index.md
@@ -18,9 +18,9 @@ Toasts display small snippets of information to the user and then disappear afte
 
 ### Accessibility
 
-<component-questions />
-
 For accessibility reasons, toasts should never contain interactive elements as interactive elements should always occur in the same location as the action that triggered it. Because of this limitation, we consider the use of toasts to be somewhat of an antipattern and recommend that another approach be found wherever possible. The Warp team will be investigating potentially better approaches for specific use cases in near future. That being said, you are free to use toast so long as you avoid using interactive elements such as links or a close button.
+
+<component-questions />
 
 ## Frameworks
 

--- a/docs/components/toast/index.md
+++ b/docs/components/toast/index.md
@@ -14,17 +14,17 @@ Toasts display small snippets of information to the user and then disappear afte
 
 ## Usage
 
+<component-design-guidelines name="Warp - Components / Button" link="https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Components?type=design&node-id=303-19039&mode=design&t=zUBVst8JZi0AR66n-0" />
+
 ### Accessibility
+
+<component-questions />
 
 For accessibility reasons, toasts should never contain interactive elements as interactive elements should always occur in the same location as the action that triggered it. Because of this limitation, we consider the use of toasts to be somewhat of an antipattern and recommend that another approach be found wherever possible. The Warp team will be investigating potentially better approaches for specific use cases in near future. That being said, you are free to use toast so long as you avoid using interactive elements such as links or a close button.
 
 ## Frameworks
 
 <tabs-content>
-  <template #react>
-  </template>
-  <template #vue>
-  </template>
   <template #elements>
     <elements />
   </template>

--- a/docs/components/utilities/index.md
+++ b/docs/components/utilities/index.md
@@ -4,7 +4,7 @@
 
 # Layout utilities
 
-These components are available to make some of the layout components interactive.
+These utility components are available to make some layout components interactive.
 
 <components-status vue='released' />
 
@@ -14,14 +14,14 @@ These components are available to make some of the layout components interactive
 
 <utilities-example />
 
+## Usage
+
+<component-questions />
+
 ## Frameworks
 
 <tabs-content>
-  <template #react>
-  </template>
   <template #vue>
     <vue />
-  </template>
-  <template #elements>
   </template>
 </tabs-content>


### PR DESCRIPTION
- Add section with design guidelines link to Figma for every component
- Add section about further usage questions with link to Slack for every component
- Align component examples visually
- Align heading levels throughout the component pages
- Attempt at having the correct type for all code blocks
- Fix elements/alert syntax example
- Removed disabled frameworks from the frameworks tabs menu
- Added missing props table for react/toggle component
- Added missing props table for react and vue TabPanel component to the Tabs page
- Fixed broken placeholder Select example
- Fixed broken read-only TextArea example
- Improved the example for Steps component
- Fix misc typos

![image](https://github.com/warp-ds/tech-docs/assets/7531505/b97e263d-caa1-4e57-84d4-6d95547e1fc9)
