### PR TITLE
fix: update attention docs

### DIFF
--- a/docs/api-table.js
+++ b/docs/api-table.js
@@ -50,6 +50,9 @@ export const react = {
       ['callout', 'boolean', '', 'Whether Attention element is rendered as a callout'],
       ['popover', 'boolean', '', 'Whether Attention element is rendered as a popover'],
       ['ref', 'Ref<HTMLDivElement>', '', 'Forward arrow ref so Attention element can use it'],
+      ['role', 'string', '', 'Sets the ARIA role attribute for the Attention element'],
+      ['aria-label', 'string', '', 'Sets the aria-label attribute for the Attention element'],
+
     ],
   },
   Badge: {

--- a/docs/api-table.js
+++ b/docs/api-table.js
@@ -50,8 +50,8 @@ export const react = {
       ['callout', 'boolean', '', 'Whether Attention element is rendered as a callout'],
       ['popover', 'boolean', '', 'Whether Attention element is rendered as a popover'],
       ['ref', 'Ref<HTMLDivElement>', '', 'Forward arrow ref so Attention element can use it'],
-      ['role', 'string', '', 'Sets the ARIA role attribute for the Attention element'],
-      ['aria-label', 'string', '', 'Sets the aria-label attribute for the Attention element'],
+      ['role', 'string', '', 'Allows the user to reset the default ARIA role attribute for the Attention element'],
+      ['aria-label', 'string', '', 'Allows the user to reset/override the default aria-label attribute for the Attention element'],
 
     ],
   },
@@ -791,6 +791,8 @@ export const vue = {
       ['callout', 'boolean', 'false', 'Whether Attention element is rendered as an inline callout'],
       ['popover', 'boolean', 'false', 'Whether Attention element is rendered as a popover'],
       ['v-model', 'boolean', '', 'Whether Attention element should be visible'],
+      ['role', 'string', '', 'Allows the user to reset the default ARIA role attribute for the Attention element'],
+      ['ariaLabel', 'string', '', 'Allows the user to reset/override the default aria-label attribute for the Attention element'],
     ],
   },
   Badge: {

--- a/docs/api-table.js
+++ b/docs/api-table.js
@@ -50,8 +50,8 @@ export const react = {
       ['callout', 'boolean', '', 'Whether Attention element is rendered as a callout'],
       ['popover', 'boolean', '', 'Whether Attention element is rendered as a popover'],
       ['ref', 'Ref<HTMLDivElement>', '', 'Forward arrow ref so Attention element can use it'],
-      ['role', 'string', '', 'Allows the user to reset the default ARIA role attribute for the Attention element'],
-      ['aria-label', 'string', '', 'Allows the user to reset/override the default aria-label attribute for the Attention element'],
+      ['role', 'string', '', 'Allows the user to override the default ARIA role attribute for the Attention element'],
+      ['aria-label', 'string', '', 'Allows the user to override the default aria-label attribute for the Attention element'],
 
     ],
   },
@@ -791,8 +791,8 @@ export const vue = {
       ['callout', 'boolean', 'false', 'Whether Attention element is rendered as an inline callout'],
       ['popover', 'boolean', 'false', 'Whether Attention element is rendered as a popover'],
       ['v-model', 'boolean', '', 'Whether Attention element should be visible'],
-      ['role', 'string', '', 'Allows the user to reset the default ARIA role attribute for the Attention element'],
-      ['ariaLabel', 'string', '', 'Allows the user to reset/override the default aria-label attribute for the Attention element'],
+      ['role', 'string', '', 'Allows the user to override the default ARIA role attribute for the Attention element'],
+      ['ariaLabel', 'string', '', 'Allows the user to override the default aria-label attribute for the Attention element'],
     ],
   },
   Badge: {

--- a/docs/components/attention/Example.vue
+++ b/docs/components/attention/Example.vue
@@ -3,7 +3,6 @@ import { ref } from 'vue'
 import { wAttention, wBox, wButton } from '@warp-ds/vue'
 
 const tooltipTarget = ref(null)
-const calloutTarget = ref(null)
 const popoverTarget = ref(null)
 
 const tooltipShowing = ref(false)

--- a/docs/components/attention/Example.vue
+++ b/docs/components/attention/Example.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { ref } from 'vue';
-import { wAttention, wBox } from '@warp-ds/vue';
+import { ref } from 'vue'
+import { wAttention, wBox } from '@warp-ds/vue'
 
 const tooltipTarget = ref(null)
 const calloutTarget = ref(null)
@@ -14,26 +14,90 @@ const popoverShowing = ref(false)
 <template>
   <div class="component space-y-16">
     <div>
-      <h3 class="h4">Callout</h3>
+      <h4>Callout</h4>
       <div class="flex items-center">
-        <w-box neutral ref="calloutTarget" @mouseenter="calloutShowing = true; target = $refs.calloutTarget" @mouseleave="calloutShowing = false">Hover over me</w-box>
-        <w-attention callout right :target-el="calloutTarget ? calloutTarget.$el : null" v-model="calloutShowing" class="ml-8">
-          <p>This is a callout</p>
+        <w-box
+          neutral
+          ref="calloutTarget"
+          aria-details="callout-bubbletext"
+          @mouseenter="calloutShowing = true; target = $refs.calloutTarget"
+          @mouseleave="calloutShowing = false"
+          @keydown.escape="calloutShowing = false"
+          @focus="calloutShowing = true"
+          @blur="calloutShowing = false"
+          tabindex="0"
+          >
+          <button>Hover over me</button>
+          </w-box
+        >
+        <w-attention
+          callout
+          right
+          :target-el="calloutTarget ? calloutTarget.$el : null"
+          v-model="calloutShowing"
+          @focus="calloutShowing = true"
+          @blur="calloutShowing = false"
+          class="ml-8"
+        >
+          <p id="callout-bubbletext" role="img">This is a callout</p>
         </w-attention>
       </div>
     </div>
     <div>
-      <h3 class="h4">Tooltip</h3>
-      <w-box neutral ref="tooltipTarget" @mouseenter="tooltipShowing = true; target = $refs.tooltipTarget" @mouseleave="tooltipShowing = false">Hover over me</w-box>
-      <w-attention tooltip bottom :target-el="tooltipTarget ? tooltipTarget.$el : null" v-model="tooltipShowing">
-        <p>This is a tooltip</p>
+      <h4>Tooltip</h4>
+      <w-box
+        neutral
+        ref="tooltipTarget"
+        aria-describedby="tooltip-text"
+        :aria-hidden="!tooltipShowing"
+        @mouseenter=" tooltipShowing = true; target = $refs.tooltipTarget"
+        @mouseleave="tooltipShowing = false"
+        @keydown.escape="tooltipShowing = false"
+        @focus="tooltipShowing = true"
+        @blur="tooltipShowing = false"
+        tabindex="0"
+        >
+        <button>Hover over me</button>
+        </w-box
+      >
+      <w-attention
+        tooltip
+        bottom
+        :target-el="tooltipTarget ? tooltipTarget.$el : null"
+        v-model="tooltipShowing"
+        @focus="tooltipShowing = true"
+        @blur="tooltipShowing = false"
+      >
+        <p id="tooltip-text" role="tooltip">This is a tooltip</p>
       </w-attention>
     </div>
     <div>
-      <h3 class="h4">Popover</h3>
-      <w-box neutral ref="popoverTarget" @mouseenter="popoverShowing = true; target = $refs.popoverTarget" @mouseleave="popoverShowing = false">Hover over me</w-box>
-      <w-attention popover bottom :target-el="popoverTarget ? popoverTarget.$el : null" v-model="popoverShowing">
-        <p>This is a popover</p>
+      <h4>Popover</h4>
+      <w-box
+        neutral
+        ref="popoverTarget"
+        :aria-expanded="popoverShowing"
+        aria-controls="pop-over-attention-example"
+        aria-details="popover-bubbletext"
+        @mouseenter="popoverShowing = true; target = $refs.popoverTarget"
+        @mouseleave="popoverShowing = false"
+        @keydown.escape="popoverShowing = false"
+        @focus="popoverShowing = true"
+        @blur="popoverShowing = false"
+        tabindex="0"
+        >
+        <button>Hover over me</button>
+        </w-box
+      >
+      <w-attention
+        popover
+        bottom
+        :target-el="popoverTarget ? popoverTarget.$el : null"
+        v-model="popoverShowing"
+        @focus="popoverShowing = true"
+        @blur="popoverShowing = false"
+      >
+        <p id="popover-bubbletext" role="img">This is a popover</p>
       </w-attention>
     </div>
   </div>

--- a/docs/components/attention/Example.vue
+++ b/docs/components/attention/Example.vue
@@ -18,7 +18,6 @@ const popoverShowing = ref(false)
       <div class="flex items-center">
         <w-box
           neutral
-          :ref="calloutTarget ? calloutTarget.$el : null"
           aria-details="callout-bubbletext"
           tabindex="0"
           >
@@ -28,7 +27,6 @@ const popoverShowing = ref(false)
         <w-attention
           callout
           right
-          :target-el="calloutTarget ? calloutTarget.$el : null"
           v-model="calloutShowing"
           class="ml-8"
         >

--- a/docs/components/attention/Example.vue
+++ b/docs/components/attention/Example.vue
@@ -28,7 +28,7 @@ const popoverShowing = ref(false)
       <h4>Tooltip</h4>
       <w-button
         utility
-        :ref="tooltipTarget ? tooltipTarget.$el : null"
+        ref="tooltipTarget"
         aria-describedby="tooltip-bubbletext"
         aria-expanded="true"
         @mouseenter="tooltipShowing = true; target = $refs.tooltipTarget"
@@ -59,7 +59,7 @@ const popoverShowing = ref(false)
         :aria-expanded="popoverShowing"
         aria-controls="popover-example"
         type="button"
-        :ref="popoverTarget ? popoverTarget.$el : null"
+        ref="popoverTarget"
         @click="() => (popoverShowing = !popoverShowing)"
       >
         Open popover

--- a/docs/components/attention/Example.vue
+++ b/docs/components/attention/Example.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref } from 'vue'
-import { wAttention, wBox } from '@warp-ds/vue'
+import { wAttention, wBox, wButton } from '@warp-ds/vue'
 
 const tooltipTarget = ref(null)
 const calloutTarget = ref(null)
@@ -16,39 +16,31 @@ const popoverShowing = ref(false)
     <div>
       <h4>Callout</h4>
       <div class="flex items-center">
-        <w-box
-          neutral
-          aria-details="callout-bubbletext"
-          tabindex="0"
-          >
+        <w-box neutral aria-details="callout-bubbletext" tabindex="0">
           I am a box full of info
-          </w-box
-        >
-        <w-attention
-          callout
-          right
-          v-model="calloutShowing"
-          class="ml-8"
-        >
+        </w-box>
+        <w-attention callout right v-model="calloutShowing" class="ml-8">
           <p id="callout-bubbletext">This is a callout</p>
         </w-attention>
       </div>
     </div>
     <div>
       <h4>Tooltip</h4>
-      <w-box
-        neutral
-        ref="tooltipTarget"
-        @mouseenter=" tooltipShowing = true; target = $refs.tooltipTarget"
+      <w-button
+        utility
+        :ref="tooltipTarget ? tooltipTarget.$el : null"
+        aria-describedby="tooltip-bubbletext"
+        aria-expanded="true"
+        @mouseenter="tooltipShowing = true; target = $refs.tooltipTarget"
         @mouseleave="tooltipShowing = false"
         @keydown.escape="tooltipShowing = false"
         @focus="tooltipShowing = true"
         @blur="tooltipShowing = false"
         tabindex="0"
-        >
-        <button aria-describedby="tooltip-bubbletext" aria-expanded="true" type="button" class="bg-transparent">Hover over me</button>
-        </w-box
+        type="button"
       >
+        Hover over me
+      </w-button>
       <w-attention
         tooltip
         bottom
@@ -62,24 +54,24 @@ const popoverShowing = ref(false)
     </div>
     <div>
       <h4>Popover</h4>
-      <button
-            :aria-expanded="popoverShowing"
-            aria-controls="popover-example"
-            type="button"
-            :ref="popoverTarget ? popoverTarget.$el : null"
-            @click="() => (popoverShowing = !popoverShowing)"
-            class="p-4 border rounded bg-transparent"
-          >
-            Open popover
-          </button>
-          <w-attention
-            popover
-            bottom
-            :target-el="popoverTarget ? popoverTarget.$el : null"
-            v-model="popoverShowing"
-          >
-            <p>Hello Warp!</p>
-          </w-attention>
+      <w-button
+        utility
+        :aria-expanded="popoverShowing"
+        aria-controls="popover-example"
+        type="button"
+        :ref="popoverTarget ? popoverTarget.$el : null"
+        @click="() => (popoverShowing = !popoverShowing)"
+      >
+        Open popover
+      </w-button>
+      <w-attention
+        popover
+        bottom
+        :target-el="popoverTarget ? popoverTarget.$el : null"
+        v-model="popoverShowing"
+      >
+        <p>Hello Warp!</p>
+      </w-attention>
     </div>
   </div>
 </template>

--- a/docs/components/attention/Example.vue
+++ b/docs/components/attention/Example.vue
@@ -19,7 +19,6 @@ const popoverShowing = ref(false)
         <w-box
           neutral
           ref="calloutTarget"
-          aria-details="callout-bubbletext"
           @mouseenter="calloutShowing = true; target = $refs.calloutTarget"
           @mouseleave="calloutShowing = false"
           @keydown.escape="calloutShowing = false"
@@ -27,7 +26,7 @@ const popoverShowing = ref(false)
           @blur="calloutShowing = false"
           tabindex="0"
           >
-          <button class="bg-transparent">Hover over me</button>
+          <button aria-describedby="callout-bubbletext" aria-expanded="true" type="button" class="bg-transparent">Hover over me</button>
           </w-box
         >
         <w-attention
@@ -39,7 +38,7 @@ const popoverShowing = ref(false)
           @blur="calloutShowing = false"
           class="ml-8"
         >
-          <p id="callout-bubbletext" role="img">This is a callout</p>
+          <p id="callout-bubbletext">This is a callout</p>
         </w-attention>
       </div>
     </div>
@@ -48,8 +47,6 @@ const popoverShowing = ref(false)
       <w-box
         neutral
         ref="tooltipTarget"
-        aria-describedby="tooltip-text"
-        :aria-hidden="!tooltipShowing"
         @mouseenter=" tooltipShowing = true; target = $refs.tooltipTarget"
         @mouseleave="tooltipShowing = false"
         @keydown.escape="tooltipShowing = false"
@@ -57,7 +54,7 @@ const popoverShowing = ref(false)
         @blur="tooltipShowing = false"
         tabindex="0"
         >
-        <button class="bg-transparent">Hover over me</button>
+        <button aria-describedby="tooltip-bubbletext" aria-expanded="true" type="button" class="bg-transparent">Hover over me</button>
         </w-box
       >
       <w-attention
@@ -68,7 +65,7 @@ const popoverShowing = ref(false)
         @focus="tooltipShowing = true"
         @blur="tooltipShowing = false"
       >
-        <p id="tooltip-text" role="tooltip">This is a tooltip</p>
+        <p id="tooltip-bubbletext">This is a tooltip</p>
       </w-attention>
     </div>
     <div>
@@ -77,8 +74,7 @@ const popoverShowing = ref(false)
         neutral
         ref="popoverTarget"
         :aria-expanded="popoverShowing"
-        aria-controls="pop-over-attention-example"
-        aria-details="popover-bubbletext"
+        aria-controls="popover-attention-example"
         @mouseenter="popoverShowing = true; target = $refs.popoverTarget"
         @mouseleave="popoverShowing = false"
         @keydown.escape="popoverShowing = false"
@@ -86,7 +82,7 @@ const popoverShowing = ref(false)
         @blur="popoverShowing = false"
         tabindex="0"
         >
-        <button class="bg-transparent">Hover over me</button>
+        <button aria-describedby="popover-bubbletext" aria-expanded="true" type="button" class="bg-transparent">Hover over me</button>
         </w-box
       >
       <w-attention
@@ -97,7 +93,7 @@ const popoverShowing = ref(false)
         @focus="popoverShowing = true"
         @blur="popoverShowing = false"
       >
-        <p id="popover-bubbletext" role="img">This is a popover</p>
+        <p id="popover-bubbletext">This is a popover</p>
       </w-attention>
     </div>
   </div>

--- a/docs/components/attention/Example.vue
+++ b/docs/components/attention/Example.vue
@@ -27,7 +27,7 @@ const popoverShowing = ref(false)
           @blur="calloutShowing = false"
           tabindex="0"
           >
-          <button>Hover over me</button>
+          <button class="bg-transparent">Hover over me</button>
           </w-box
         >
         <w-attention
@@ -57,7 +57,7 @@ const popoverShowing = ref(false)
         @blur="tooltipShowing = false"
         tabindex="0"
         >
-        <button>Hover over me</button>
+        <button class="bg-transparent">Hover over me</button>
         </w-box
       >
       <w-attention
@@ -86,7 +86,7 @@ const popoverShowing = ref(false)
         @blur="popoverShowing = false"
         tabindex="0"
         >
-        <button>Hover over me</button>
+        <button class="bg-transparent">Hover over me</button>
         </w-box
       >
       <w-attention

--- a/docs/components/attention/Example.vue
+++ b/docs/components/attention/Example.vue
@@ -7,7 +7,7 @@ const calloutTarget = ref(null)
 const popoverTarget = ref(null)
 
 const tooltipShowing = ref(false)
-const calloutShowing = ref(false)
+const calloutShowing = ref(true)
 const popoverShowing = ref(false)
 </script>
 
@@ -18,15 +18,11 @@ const popoverShowing = ref(false)
       <div class="flex items-center">
         <w-box
           neutral
-          ref="calloutTarget"
-          @mouseenter="calloutShowing = true; target = $refs.calloutTarget"
-          @mouseleave="calloutShowing = false"
-          @keydown.escape="calloutShowing = false"
-          @focus="calloutShowing = true"
-          @blur="calloutShowing = false"
+          :ref="calloutTarget ? calloutTarget.$el : null"
+          aria-details="callout-bubbletext"
           tabindex="0"
           >
-          <button aria-describedby="callout-bubbletext" aria-expanded="true" type="button" class="bg-transparent">Hover over me</button>
+          I am a box full of info
           </w-box
         >
         <w-attention
@@ -34,8 +30,6 @@ const popoverShowing = ref(false)
           right
           :target-el="calloutTarget ? calloutTarget.$el : null"
           v-model="calloutShowing"
-          @focus="calloutShowing = true"
-          @blur="calloutShowing = false"
           class="ml-8"
         >
           <p id="callout-bubbletext">This is a callout</p>
@@ -70,31 +64,24 @@ const popoverShowing = ref(false)
     </div>
     <div>
       <h4>Popover</h4>
-      <w-box
-        neutral
-        ref="popoverTarget"
-        :aria-expanded="popoverShowing"
-        aria-controls="popover-attention-example"
-        @mouseenter="popoverShowing = true; target = $refs.popoverTarget"
-        @mouseleave="popoverShowing = false"
-        @keydown.escape="popoverShowing = false"
-        @focus="popoverShowing = true"
-        @blur="popoverShowing = false"
-        tabindex="0"
-        >
-        <button aria-describedby="popover-bubbletext" aria-expanded="true" type="button" class="bg-transparent">Hover over me</button>
-        </w-box
-      >
-      <w-attention
-        popover
-        bottom
-        :target-el="popoverTarget ? popoverTarget.$el : null"
-        v-model="popoverShowing"
-        @focus="popoverShowing = true"
-        @blur="popoverShowing = false"
-      >
-        <p id="popover-bubbletext">This is a popover</p>
-      </w-attention>
+      <button
+            :aria-expanded="popoverShowing"
+            aria-controls="popover-example"
+            type="button"
+            :ref="popoverTarget ? popoverTarget.$el : null"
+            @click="() => (popoverShowing = !popoverShowing)"
+            class="p-4 border rounded bg-transparent"
+          >
+            Open popover
+          </button>
+          <w-attention
+            popover
+            bottom
+            :target-el="popoverTarget ? popoverTarget.$el : null"
+            v-model="popoverShowing"
+          >
+            <p>Hello Warp!</p>
+          </w-attention>
     </div>
   </div>
 </template>

--- a/docs/components/attention/elements.md
+++ b/docs/components/attention/elements.md
@@ -36,7 +36,7 @@
 ### Accessibility
 If the Attention element has "left" or "top" position, it should be placed before the target element in the DOM.
 
-Attention element handles accessibility automatically by wrapping its slotted content with a `div` with either `role="tooltip"` for tooltip or `role="img"` for callout and popover, a default `aria-label` and setting an `aria-details` attribute on the target element. The default `aria-label` also supports i18n. 
+Attention element handles accessibility automatically by wrapping its slotted content with a `div` that has a default `role` attribute (`role="tooltip"` for tooltip and `role="img"` otherwise), and a default localized `aria-label`. In addition, Attention automatically sets an `aria-details` on its target element, pointing to the slotted message element.
 
 It is possible to tell assistive technologies to recognize only a part of Attention's text content. To do that set the `role` attribute on the relevant text element nested in `w-attention` and reference it by id through the use of `aria-details`. The `aria-details` attribute is on the target element, not on `w-attention`.
 

--- a/docs/components/attention/elements.md
+++ b/docs/components/attention/elements.md
@@ -46,7 +46,7 @@ It is possible to tell assistive technologies to recognize only a part of Attent
     <p id="aria-content" role="tooltip">I'm a popover with ARIA "tooltip" role</p>
     <p>(this text is less relevant)</p>
   </div>
-  <button aria-details="aria-content" id="target" slot="target">
+  <button aria-describedby="aria-content" id="target" slot="target">
     Click to toggle a popover on top
   </button>
 </w-attention>

--- a/docs/components/attention/elements.md
+++ b/docs/components/attention/elements.md
@@ -36,9 +36,9 @@
 ### Accessibility
 If the Attention element has "left" or "top" position, it should be placed before the target element in the DOM.
 
-Attention element handles accessibility automatically by wrapping its slotted content with a `div` with `role="tooltip"`, and setting an aria-describedby attribute on the target element.
+Attention element handles accessibility automatically by wrapping its slotted content with a `div` with either `role="tooltip"` for tooltip or `role="img"` for callout and popover, a default `aria-label` and setting an `aria-details` attribute on the target element. The default `aria-label` also supports i18n. 
 
-It is possible to tell assistive technologies to recognize only a part of Attention's text content. To do that set `role="tooltip"` on the relevant text element nested in `w-attention` and reference it by id through the use of `aria-describedby`. The `aria-describedby` attribute is on the target element, not on `w-attention`.
+It is possible to tell assistive technologies to recognize only a part of Attention's text content. To do that set the `role` attribute on the relevant text element nested in `w-attention` and reference it by id through the use of `aria-details`. The `aria-details` attribute is on the target element, not on `w-attention`.
 
 ```js
 <w-attention placement="top" popover="">
@@ -46,7 +46,7 @@ It is possible to tell assistive technologies to recognize only a part of Attent
     <p id="aria-content" role="tooltip">I'm a popover with ARIA "tooltip" role</p>
     <p>(this text is less relevant)</p>
   </div>
-  <button aria-describedby="aria-content" id="target" slot="target">
+  <button aria-details="aria-content" id="target" slot="target">
     Click to toggle a popover on top
   </button>
 </w-attention>

--- a/docs/components/attention/react.md
+++ b/docs/components/attention/react.md
@@ -11,10 +11,10 @@ import { Attention } from '@warp-ds/react';
 ```js
 <div>
   <Box info>
-    <h1>I am a box full of info</h1>
+    <h1 aria-details="callout-bubbletext">I am a box full of info</h1>
   </Box>
   <Attention callout placement="right" isShowing={true}>
-    <p>I'm a callout because that box over there is new or something</p>
+    <p id="callout-bubbletext">I'm a callout because that box over there is new or something</p>
   </Attention>
 </div>
 ```
@@ -32,8 +32,16 @@ function Example() {
         ref={targetEl}
         onMouseEnter={() => setShow(true)}
         onMouseLeave={() => setShow(false)}
+        aria-describedby='tooltip-text'
+        aria-hidden={!show}
+        onMouseEnter={() => setShow(true)}
+        onMouseLeave={() => setShow(false)}
+        onFocus={() => setShow(true)}
+        onBlur={() => setShow(false)}
+        onKeyDown={handleKeyDown}
+        tabIndex={0}
       >
-        hover this for useless info
+        <button>hover this for useless info</button>
       </h1>
       <Attention
         tooltip
@@ -41,7 +49,7 @@ function Example() {
         targetEl={targetEl}
         isShowing={show}
       >
-        <p>lol i am a popover</p>
+        <p id="tooltip-text" role="tooltip">lol i am a popover</p>
       </Attention>
     </div>
   );
@@ -72,6 +80,9 @@ function Example() {
     <div ref={containerRef}>
       <Button
         small
+        aria-expanded={show}
+        aria-controls='pop-over-attention-example'
+        aria-details='pop-over-bubbletext'
         utility
         onClick={() => setShow(!show)}
         ref={targetEl}
@@ -84,7 +95,7 @@ function Example() {
         targetEl={targetEl}
         isShowing={show}
       >
-        <ul>
+        <ul id="pop-over-bubbletext">
           <li tabIndex={0} >
             Hello
           </li>

--- a/docs/components/attention/react.md
+++ b/docs/components/attention/react.md
@@ -30,20 +30,16 @@ function Example() {
 
   return (
     <div>
-      <h1
-        ref={targetEl}
-        onMouseEnter={() => setShow(true)}
-        onMouseLeave={() => setShow(false)}
-        onFocus={() => setShow(true)}
-        onBlur={() => setShow(false)}
-        onKeyDown={handleKeyDown}
-        tabIndex={0}
-      >
+      <h1 ref={targetEl}>
         <Button
           utility
           aria-describedby='tooltip-bubbletext'
           aria-expanded='true'
           type='button'
+          onMouseEnter={() => setShow(true)}
+          onMouseLeave={() => setShow(false)}
+          onFocus={() => setShow(true)}
+          onBlur={() => setShow(false)}
         >
           hover this for useless info
         </Button>
@@ -123,6 +119,7 @@ It is possible to override the `role` and `aria-label` attributes:
   </p>
 </Attention>
 ```
+
 If the user chooses to override the `role` and `aria-label` attributes then it is important to also add `aria-details` on the target element. <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-details">Read more about `aria-detail` here</a>
 
 ### Props

--- a/docs/components/attention/react.md
+++ b/docs/components/attention/react.md
@@ -123,6 +123,7 @@ It is possible to override the `role` and `aria-label` attributes:
   </p>
 </Attention>
 ```
+If the user chooses to override the `role` and `aria-label` attributes then it is important to also add `aria-details` on the target element. <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-details">Read more about `aria-detail` here</a>
 
 ### Props
 

--- a/docs/components/attention/react.md
+++ b/docs/components/attention/react.md
@@ -115,9 +115,9 @@ function Example() {
 
 ### Accessibility
 
-The attention element handles accessibility automatically by wrapping its slotted content with a `div` with either `role="tooltip"` for tooltip or `role="img"` for callout and popover, as well as, setting a default `aria-label`. The default `aria-label` also supports i18n.
+The attention element handles accessibility automatically by wrapping its slotted content with a `div` that has a default `role`attribute (`role="tooltip"` for tooltip and `role="img"` otherwise), and a default localized `aria-label`.
 
-It is possible to reset the `role` and `aria-label` attributes, and it is also possible to override the default `aria-label`:
+It is possible to reset the `role` and `aria-label` attributes, and the default `aria-label` can be overridden:
 
 ```js
 <div className="flex items-center">

--- a/docs/components/attention/react.md
+++ b/docs/components/attention/react.md
@@ -30,20 +30,19 @@ function Example() {
 
   return (
     <div>
-      <h1 ref={targetEl}>
-        <Button
-          utility
-          aria-describedby='tooltip-bubbletext'
-          aria-expanded='true'
-          type='button'
-          onMouseEnter={() => setShow(true)}
-          onMouseLeave={() => setShow(false)}
-          onFocus={() => setShow(true)}
-          onBlur={() => setShow(false)}
-        >
-          hover this for useless info
-        </Button>
-      </h1>
+      <Button
+        ref={targetEl}
+        utility
+        aria-describedby='tooltip-bubbletext'
+        aria-expanded='true'
+        type='button'
+        onMouseEnter={() => setShow(true)}
+        onMouseLeave={() => setShow(false)}
+        onFocus={() => setShow(true)}
+        onBlur={() => setShow(false)}
+      >
+        hover this for useless info
+      </Button>
       <Attention
         tooltip
         placement='bottom'

--- a/docs/components/attention/react.md
+++ b/docs/components/attention/react.md
@@ -113,6 +113,32 @@ function Example() {
 }
 ```
 
+### Accessibility
+
+The attention element handles accessibility automatically by wrapping its slotted content with a `div` with either `role="tooltip"` for tooltip or `role="img"` for callout and popover, as well as, setting a default `aria-label`. The default `aria-label` also supports i18n.
+
+It is possible to reset the `role` and `aria-label` attributes, and it is also possible to override the default `aria-label`:
+
+```js
+<div className="flex items-center">
+  <Box info>
+    <h1 aria-details='callout-bubbletext'>I am a box full of info</h1>
+  </Box>
+  <Attention
+    callout
+    placement='right'
+    isShowing={true}
+    role=''
+    aria-label='overriding default aria-label'
+  >
+  <p id='callout-bubbletext' role='img' style={{ width: 200 }}>
+    I'm a callout speech bubble with resetted role and overridden aria-label
+    attributes pointing left.
+  </p>
+  </Attention>
+</div>
+```
+
 ### Props
 
 <api-table type="react" component="Attention" />

--- a/docs/components/attention/react.md
+++ b/docs/components/attention/react.md
@@ -32,8 +32,6 @@ function Example() {
         ref={targetEl}
         onMouseEnter={() => setShow(true)}
         onMouseLeave={() => setShow(false)}
-        aria-describedby='tooltip-text'
-        aria-hidden={!show}
         onMouseEnter={() => setShow(true)}
         onMouseLeave={() => setShow(false)}
         onFocus={() => setShow(true)}
@@ -41,7 +39,14 @@ function Example() {
         onKeyDown={handleKeyDown}
         tabIndex={0}
       >
-        <button>hover this for useless info</button>
+        <button
+          aria-describedby='tooltip-bubbletext'
+          aria-expanded='true'
+          type='button'
+          className='bg-transparent'
+        >
+          hover this for useless info
+        </button>
       </h1>
       <Attention
         tooltip
@@ -49,7 +54,7 @@ function Example() {
         targetEl={targetEl}
         isShowing={show}
       >
-        <p id="tooltip-text" role="tooltip">lol i am a popover</p>
+        <p id="tooltip-bubbletext">lol i am a popover</p>
       </Attention>
     </div>
   );
@@ -81,8 +86,8 @@ function Example() {
       <Button
         small
         aria-expanded={show}
-        aria-controls='pop-over-attention-example'
-        aria-details='pop-over-bubbletext'
+        aria-controls='popover-example'
+        aria-details='popover-bubbletext'
         utility
         onClick={() => setShow(!show)}
         ref={targetEl}
@@ -95,7 +100,7 @@ function Example() {
         targetEl={targetEl}
         isShowing={show}
       >
-        <ul id="pop-over-bubbletext">
+        <ul id="popover-bubbletext">
           <li tabIndex={0} >
             Hello
           </li>

--- a/docs/components/attention/react.md
+++ b/docs/components/attention/react.md
@@ -86,8 +86,7 @@ function Example() {
       <Button
         small
         aria-expanded={show}
-        aria-controls='popover-example'
-        aria-details='popover-bubbletext'
+        aria-controls='popover-attention-example'
         utility
         onClick={() => setShow(!show)}
         ref={targetEl}
@@ -100,7 +99,7 @@ function Example() {
         targetEl={targetEl}
         isShowing={show}
       >
-        <ul id="popover-bubbletext">
+        <ul>
           <li tabIndex={0} >
             Hello
           </li>

--- a/docs/components/attention/react.md
+++ b/docs/components/attention/react.md
@@ -1,7 +1,7 @@
 ### Import
 
 ```js
-import { Attention } from '@warp-ds/react';
+import { Attention } from '@warp-ds/react'
 ```
 
 ### Visual options
@@ -11,10 +11,12 @@ import { Attention } from '@warp-ds/react';
 ```js
 <div>
   <Box info>
-    <h1 aria-details="callout-bubbletext">I am a box full of info</h1>
+    <h1 aria-details='callout-bubbletext'>I am a box full of info</h1>
   </Box>
-  <Attention callout placement="right" isShowing={true}>
-    <p id="callout-bubbletext">I'm a callout because that box over there is new or something</p>
+  <Attention callout placement='right' isShowing={true}>
+    <p id='callout-bubbletext'>
+      I'm a callout because that box over there is new or something
+    </p>
   </Attention>
 </div>
 ```
@@ -23,8 +25,8 @@ import { Attention } from '@warp-ds/react';
 
 ```js
 function Example() {
-  const [show, setShow] = React.useState(false);
-  const targetEl = React.useRef();
+  const [show, setShow] = React.useState(false)
+  const targetEl = React.useRef()
 
   return (
     <div>
@@ -32,32 +34,30 @@ function Example() {
         ref={targetEl}
         onMouseEnter={() => setShow(true)}
         onMouseLeave={() => setShow(false)}
-        onMouseEnter={() => setShow(true)}
-        onMouseLeave={() => setShow(false)}
         onFocus={() => setShow(true)}
         onBlur={() => setShow(false)}
         onKeyDown={handleKeyDown}
         tabIndex={0}
       >
-        <button
+        <Button
+          utility
           aria-describedby='tooltip-bubbletext'
           aria-expanded='true'
           type='button'
-          className='bg-transparent'
         >
           hover this for useless info
-        </button>
+        </Button>
       </h1>
       <Attention
         tooltip
-        placement="bottom"
+        placement='bottom'
         targetEl={targetEl}
         isShowing={show}
       >
-        <p id="tooltip-bubbletext">lol i am a popover</p>
+        <p id='tooltip-bubbletext'>I am a tooltip</p>
       </Attention>
     </div>
-  );
+  )
 }
 ```
 
@@ -65,21 +65,21 @@ function Example() {
 
 ```js
 function Example() {
-  const [show, setShow] = React.useState(false);
-  const containerRef = React.useRef();
-  const targetEl = React.useRef();
+  const [show, setShow] = React.useState(false)
+  const containerRef = React.useRef()
+  const targetEl = React.useRef()
 
   React.useEffect(() => {
     function onBlurHandler(e) {
       if (containerRef.current && !containerRef.current.contains(e.target)) {
-        setShow(false);
+        setShow(false)
       }
     }
-    document.addEventListener('mousedown', onBlurHandler);
+    document.addEventListener('mousedown', onBlurHandler)
     return () => {
-      document.removeEventListener('mousedown', onBlurHandler);
-    };
-  });
+      document.removeEventListener('mousedown', onBlurHandler)
+    }
+  })
 
   return (
     <div ref={containerRef}>
@@ -95,48 +95,33 @@ function Example() {
       </Button>
       <Attention
         popover
-        placement="bottom"
+        placement='bottom'
         targetEl={targetEl}
         isShowing={show}
       >
         <ul>
-          <li tabIndex={0} >
-            Hello
-          </li>
-          <li tabIndex={0} >
-            World
-          </li>
+          <li tabIndex={0}>Hello</li>
+          <li tabIndex={0}>World</li>
         </ul>
       </Attention>
     </div>
-  );
+  )
 }
 ```
 
 ### Accessibility
 
-The attention element handles accessibility automatically by wrapping its slotted content with a `div` that has a default `role`attribute (`role="tooltip"` for tooltip and `role="img"` otherwise), and a default localized `aria-label`.
+The attention component handles accessibility automatically by wrapping its slotted content with a `div` that has a default `role` attribute (`role="tooltip"` for tooltip and `role="img"` otherwise), and a default localized `aria-label`.
 
-It is possible to reset the `role` and `aria-label` attributes, and the default `aria-label` can be overridden:
+It is possible to override the `role` and `aria-label` attributes:
 
 ```js
-<div className="flex items-center">
-  <Box info>
-    <h1 aria-details='callout-bubbletext'>I am a box full of info</h1>
-  </Box>
-  <Attention
-    callout
-    placement='right'
-    isShowing={true}
-    role=''
-    aria-label='overriding default aria-label'
-  >
-  <p id='callout-bubbletext' role='img' style={{ width: 200 }}>
-    I'm a callout speech bubble with resetted role and overridden aria-label
-    attributes pointing left.
+<Attention tooltip placement='right' isShowing={true} role='' aria-label=''>
+  <p id='tooltip-bubbletext' role='tooltip'>
+    I'm a tooltip speech bubble with overridden role and aria-label attributes
+    pointing up.
   </p>
-  </Attention>
-</div>
+</Attention>
 ```
 
 ### Props

--- a/docs/components/attention/vue.md
+++ b/docs/components/attention/vue.md
@@ -22,7 +22,6 @@ import { wAttention } from '@warp-ds/vue'
 import { ref } from 'vue'
 import { wAttention, wBox } from '#components'
 
-const target = ref(null)
 const showing = ref(false)
 </script>
 <template>
@@ -51,7 +50,7 @@ const showing = ref(false)
     :aria-expanded="showing"
     aria-controls="popover-example"
     type="button"
-    :ref="target ? target.$el : null"
+    ref="target"
     @click="() => (showing = !showing)"
   >
     Open popover
@@ -80,7 +79,7 @@ const showing = ref(false)
 <template>
   <w-button
     utility
-    :ref="target ? target.$el : null"
+    ref="target"
     aria-describedby="tooltip-bubbletext"
     aria-expanded="true"
     @mouseenter="showing = true; target = $refs.target"

--- a/docs/components/attention/vue.md
+++ b/docs/components/attention/vue.md
@@ -3,14 +3,14 @@
 > Use in entire app
 
 ```js
-import { Attention } from '@warp-ds/vue';
-app.use(Attention);
+import { Attention } from '@warp-ds/vue'
+app.use(Attention)
 ```
 
 > Use in one component and special imports
 
 ```js
-import { wAttention } from '@warp-ds/vue';
+import { wAttention } from '@warp-ds/vue'
 ```
 
 ### Visual options
@@ -26,9 +26,29 @@ const target = ref(null)
 const showing = ref(false)
 </script>
 <template>
-  <w-box neutral class="h4" ref="target" @mouseenter="showing = true" @mouseleave="showing = false">Hover over me</w-box>
-  <w-attention callout right :target-el="target?.$el" v-model="showing">
-    <p>Hello Warp!</p>
+  <w-box
+    neutral
+    as="h4"
+    ref="target"
+    aria-details="callout-bubbletext"
+    @mouseenter="showing = true"
+    @mouseleave="showing = false"
+    @keydown.escape="showing = false"
+    @focus="showing = true"
+    @blur="showing = false"
+    tabindex="0"
+  >
+    <button>Hover over me</button>
+  </w-box>
+  <w-attention
+    callout
+    right
+    :target-el="target?.$el"
+    v-model="showing"
+    @focus="showing = true"
+    @blur="showing = false"
+  >
+    <p id="callout-bubbletext" role="img">Hello Warp!</p>
   </w-attention>
 </template>
 ```
@@ -44,9 +64,31 @@ const target = ref(null)
 const showing = ref(false)
 </script>
 <template>
-  <w-box neutral class="h4" ref="target" @mouseenter="showing = true" @mouseleave="showing = false">Hover over me</w-box>
-  <w-attention popover right :target-el="target?.$el" v-model="showing">
-    <p>Hello Warp!</p>
+  <w-box
+    neutral
+    as="h4"
+    ref="target"
+    :aria-expanded="showing"
+    aria-controls="pop-over-attention-example"
+    aria-details="popover-bubbletext"
+    @mouseenter="showing = true"
+    @mouseleave="showing = false"
+    @keydown.escape="showing = false"
+    @focus="showing = true"
+    @blur="showing = false"
+    tabindex="0"
+  >
+    <button>Hover over me</button>
+  </w-box>
+  <w-attention
+    popover
+    right
+    :target-el="target?.$el"
+    v-model="showing"
+    @focus="showing = true"
+    @blur="showing = false"
+  >
+    <p id="popover-bubbletext" role="img">Hello Warp!</p>
   </w-attention>
 </template>
 ```
@@ -62,9 +104,30 @@ const target = ref(null)
 const showing = ref(false)
 </script>
 <template>
-  <w-box neutral class="h4" ref="target" @mouseenter="showing = true" @mouseleave="showing = false">Hover over me</w-box>
-  <w-attention tooltip bottom :target-el="target?.$el" v-model="showing">
-    <p>Hello Warp!</p>
+  <w-box
+    neutral
+    as="h4"
+    ref="target"
+    aria-describedby="tooltip-text"
+    :aria-hidden="!showing"
+    @mouseenter="showing = true"
+    @mouseleave="showing = false"
+    @keydown.escape="showing = false"
+    @focus="showing = true"
+    @blur="showing = false"
+    tabindex="0"
+  >
+    <button>Hover over me</button>
+  </w-box>
+  <w-attention
+    tooltip
+    bottom
+    :target-el="target?.$el"
+    v-model="showing"
+    @focus="showing = true"
+    @blur="showing = false"
+  >
+    <p id="tooltip-text" role="img">Hello Warp!</p>
   </w-attention>
 </template>
 ```

--- a/docs/components/attention/vue.md
+++ b/docs/components/attention/vue.md
@@ -120,9 +120,9 @@ const showing = ref(false)
 
 ### Accessibility
 
-The attention element handles accessibility automatically by wrapping its slotted content with a `div` with either `role="tooltip"` for tooltip or `role="img"` for callout and popover, as well as, setting a default `aria-label`. The default `aria-label` also supports i18n.
+The attention element handles accessibility automatically by wrapping its slotted content with a `div` that has a default `role`attribute (`role="tooltip"` for tooltip and `role="img"` otherwise), and a default localized `aria-label`.
 
-It is possible to reset the `role` and `aria-label` attributes, and it is also possible to override the default `aria-label`:
+It is possible to reset the `role` and `aria-label` attributes, and the default `aria-label` can be overridden:
 
 ```js
 <div class="flex items-center">

--- a/docs/components/attention/vue.md
+++ b/docs/components/attention/vue.md
@@ -29,28 +29,19 @@ const showing = ref(false)
   <w-box
     neutral
     as="h4"
-    ref="target"
-    @mouseenter="showing = true"
-    @mouseleave="showing = false"
-    @keydown.escape="showing = false"
-    @focus="showing = true"
-    @blur="showing = false"
+    :ref="target ? target.$el : null"
+    aria-details="callout-bubbletext"
     tabindex="0"
   >
-    <button aria-describedby="callout-bubbletext" aria-expanded="true" type="button">
-      Hover over me
-    </button>
-
+    I am a box full of info
   </w-box>
   <w-attention
     callout
     right
-    :target-el="target?.$el"
     v-model="showing"
-    @focus="showing = true"
-    @blur="showing = false"
+    :target-el="target ? target.$el : null"
   >
-    <p id="callout-bubbletext">Hello Warp!</p>
+    <p id="callout-bubbletext">Hello Warp! This thing is new!</p>
   </w-attention>
 </template>
 ```
@@ -66,34 +57,22 @@ const target = ref(null)
 const showing = ref(false)
 </script>
 <template>
-  <w-box
-    neutral
-    as="h4"
-    ref="target"
+  <button
     :aria-expanded="showing"
-    aria-controls="pop-over-attention-example"
-    aria-details="popover-bubbletext"
-    @mouseenter="showing = true"
-    @mouseleave="showing = false"
-    @keydown.escape="showing = false"
-    @focus="showing = true"
-    @blur="showing = false"
-    tabindex="0"
+    aria-controls="popover-example"
+    type="button"
+    :ref="target ? target.$el : null"
+    @click="() => (showing = !showing)"
   >
-  <button aria-describedby="popover-bubbletext" aria-expanded="true" type="button"
-    Hover over me
+    Open popover
   </button>
-
-  </w-box>
   <w-attention
     popover
-    right
-    :target-el="target?.$el"
+    bottom
+    :target-el="target ? target.$el : null"
     v-model="showing"
-    @focus="showing = true"
-    @blur="showing = false"
   >
-    <p id="popover-bubbletext">Hello Warp!</p>
+    <p>Hello Warp!</p>
   </w-attention>
 </template>
 ```
@@ -120,10 +99,13 @@ const showing = ref(false)
     @blur="showing = false"
     tabindex="0"
   >
-  <button aria-describedby="tooltip-bubbletext" aria-expanded="true" type="button">
-    Hover over me
-  </button>
-
+    <button
+      aria-describedby="tooltip-bubbletext"
+      aria-expanded="true"
+      type="button"
+    >
+      Hover over me
+    </button>
   </w-box>
   <w-attention
     tooltip

--- a/docs/components/attention/vue.md
+++ b/docs/components/attention/vue.md
@@ -121,6 +121,8 @@ It is possible to override the `role` and `aria-label` attributes:
 </w-attention>
 ```
 
+If the user chooses to override the `role` and `aria-label` attributes then it is important to also add `aria-details` on the target element. <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-details">Read more about `aria-detail` here</a>
+
 ### Props
 
 <api-table type="vue" component="Attention" />

--- a/docs/components/attention/vue.md
+++ b/docs/components/attention/vue.md
@@ -29,7 +29,6 @@ const showing = ref(false)
   <w-box
     neutral
     as="h4"
-    :ref="target ? target.$el : null"
     aria-details="callout-bubbletext"
     tabindex="0"
   >
@@ -39,7 +38,6 @@ const showing = ref(false)
     callout
     right
     v-model="showing"
-    :target-el="target ? target.$el : null"
   >
     <p id="callout-bubbletext">Hello Warp! This thing is new!</p>
   </w-attention>
@@ -131,7 +129,6 @@ It is possible to reset the `role` and `aria-label` attributes, and it is also p
   <w-box
     neutral
     as="h4"
-    :ref="target ? target.$el : null"
     aria-details="callout-bubbletext"
     tabindex="0"
   >
@@ -141,7 +138,6 @@ It is possible to reset the `role` and `aria-label` attributes, and it is also p
     callout
     right
     v-model="showing"
-    :target-el="target ? target.$el : null"
     role=""
     ariaLabel="overriding default aria-label"
     class="ml-8"

--- a/docs/components/attention/vue.md
+++ b/docs/components/attention/vue.md
@@ -120,6 +120,39 @@ const showing = ref(false)
 </template>
 ```
 
+### Accessibility
+
+The attention element handles accessibility automatically by wrapping its slotted content with a `div` with either `role="tooltip"` for tooltip or `role="img"` for callout and popover, as well as, setting a default `aria-label`. The default `aria-label` also supports i18n.
+
+It is possible to reset the `role` and `aria-label` attributes, and it is also possible to override the default `aria-label`:
+
+```js
+<div class="flex items-center">
+  <w-box
+    neutral
+    as="h4"
+    :ref="target ? target.$el : null"
+    aria-details="callout-bubbletext"
+    tabindex="0"
+  >
+    I am a box full of info
+  </w-box>
+  <w-attention
+    callout
+    right
+    v-model="showing"
+    :target-el="target ? target.$el : null"
+    role=""
+    ariaLabel="overriding default aria-label"
+    class="ml-8"
+  >
+  <p id="callout-bubbletext">
+    Hello Warp! This thing is new!
+  </p>
+  </w-attention>
+</div>
+```
+
 ### Props
 
 <api-table type="vue" component="Attention" />

--- a/docs/components/attention/vue.md
+++ b/docs/components/attention/vue.md
@@ -30,7 +30,6 @@ const showing = ref(false)
     neutral
     as="h4"
     ref="target"
-    aria-details="callout-bubbletext"
     @mouseenter="showing = true"
     @mouseleave="showing = false"
     @keydown.escape="showing = false"
@@ -38,7 +37,10 @@ const showing = ref(false)
     @blur="showing = false"
     tabindex="0"
   >
-    <button>Hover over me</button>
+    <button aria-describedby="callout-bubbletext" aria-expanded="true" type="button">
+      Hover over me
+    </button>
+
   </w-box>
   <w-attention
     callout
@@ -48,7 +50,7 @@ const showing = ref(false)
     @focus="showing = true"
     @blur="showing = false"
   >
-    <p id="callout-bubbletext" role="img">Hello Warp!</p>
+    <p id="callout-bubbletext">Hello Warp!</p>
   </w-attention>
 </template>
 ```
@@ -78,7 +80,10 @@ const showing = ref(false)
     @blur="showing = false"
     tabindex="0"
   >
-    <button>Hover over me</button>
+  <button aria-describedby="popover-bubbletext" aria-expanded="true" type="button"
+    Hover over me
+  </button>
+
   </w-box>
   <w-attention
     popover
@@ -88,7 +93,7 @@ const showing = ref(false)
     @focus="showing = true"
     @blur="showing = false"
   >
-    <p id="popover-bubbletext" role="img">Hello Warp!</p>
+    <p id="popover-bubbletext">Hello Warp!</p>
   </w-attention>
 </template>
 ```
@@ -108,8 +113,6 @@ const showing = ref(false)
     neutral
     as="h4"
     ref="target"
-    aria-describedby="tooltip-text"
-    :aria-hidden="!showing"
     @mouseenter="showing = true"
     @mouseleave="showing = false"
     @keydown.escape="showing = false"
@@ -117,7 +120,10 @@ const showing = ref(false)
     @blur="showing = false"
     tabindex="0"
   >
-    <button>Hover over me</button>
+  <button aria-describedby="tooltip-bubbletext" aria-expanded="true" type="button">
+    Hover over me
+  </button>
+
   </w-box>
   <w-attention
     tooltip
@@ -127,7 +133,7 @@ const showing = ref(false)
     @focus="showing = true"
     @blur="showing = false"
   >
-    <p id="tooltip-text" role="img">Hello Warp!</p>
+    <p id="tooltip-bubbletext">Hello Warp!</p>
   </w-attention>
 </template>
 ```

--- a/docs/components/attention/vue.md
+++ b/docs/components/attention/vue.md
@@ -26,19 +26,10 @@ const target = ref(null)
 const showing = ref(false)
 </script>
 <template>
-  <w-box
-    neutral
-    as="h4"
-    aria-details="callout-bubbletext"
-    tabindex="0"
-  >
+  <w-box neutral as="h4" aria-details="callout-bubbletext" tabindex="0">
     I am a box full of info
   </w-box>
-  <w-attention
-    callout
-    right
-    v-model="showing"
-  >
+  <w-attention callout right v-model="showing">
     <p id="callout-bubbletext">Hello Warp! This thing is new!</p>
   </w-attention>
 </template>
@@ -49,13 +40,14 @@ const showing = ref(false)
 ```vue
 <script>
 import { ref } from 'vue'
-import { wAttention, wBox } from '#components'
+import { wAttention, wButton } from '#components'
 
 const target = ref(null)
 const showing = ref(false)
 </script>
 <template>
-  <button
+  <w-button
+    utility
     :aria-expanded="showing"
     aria-controls="popover-example"
     type="button"
@@ -63,7 +55,7 @@ const showing = ref(false)
     @click="() => (showing = !showing)"
   >
     Open popover
-  </button>
+  </w-button>
   <w-attention
     popover
     bottom
@@ -80,31 +72,27 @@ const showing = ref(false)
 ```vue
 <script>
 import { ref } from 'vue'
-import { wAttention, wBox } from '#components'
+import { wAttention, wButton } from '#components'
 
 const target = ref(null)
 const showing = ref(false)
 </script>
 <template>
-  <w-box
-    neutral
-    as="h4"
-    ref="target"
-    @mouseenter="showing = true"
+  <w-button
+    utility
+    :ref="target ? target.$el : null"
+    aria-describedby="tooltip-bubbletext"
+    aria-expanded="true"
+    @mouseenter="showing = true; target = $refs.target"
     @mouseleave="showing = false"
     @keydown.escape="showing = false"
     @focus="showing = true"
     @blur="showing = false"
     tabindex="0"
+    type="button"
   >
-    <button
-      aria-describedby="tooltip-bubbletext"
-      aria-expanded="true"
-      type="button"
-    >
-      Hover over me
-    </button>
-  </w-box>
+    Hover over me
+  </w-button>
   <w-attention
     tooltip
     bottom
@@ -120,33 +108,17 @@ const showing = ref(false)
 
 ### Accessibility
 
-The attention element handles accessibility automatically by wrapping its slotted content with a `div` that has a default `role`attribute (`role="tooltip"` for tooltip and `role="img"` otherwise), and a default localized `aria-label`.
+The attention component handles accessibility automatically by wrapping its slotted content with a `div` that has a default `role` attribute (`role="tooltip"` for tooltip and `role="img"` otherwise), and a default localized `aria-label`.
 
-It is possible to reset the `role` and `aria-label` attributes, and the default `aria-label` can be overridden:
+It is possible to override the `role` and `aria-label` attributes:
 
 ```js
-<div class="flex items-center">
-  <w-box
-    neutral
-    as="h4"
-    aria-details="callout-bubbletext"
-    tabindex="0"
-  >
-    I am a box full of info
-  </w-box>
-  <w-attention
-    callout
-    right
-    v-model="showing"
-    role=""
-    ariaLabel="overriding default aria-label"
-    class="ml-8"
-  >
-  <p id="callout-bubbletext">
-    Hello Warp! This thing is new!
+<w-attention tooltip bottom v-model='tooltipShowing' role='' ariaLabel=''>
+  <p id='tooltip-bubbletext' role='tooltip'>
+    I'm a tooltip speech bubble with overridden role and aria-label attributes
+    pointing up.
   </p>
-  </w-attention>
-</div>
+</w-attention>
 ```
 
 ### Props

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@warp-ds/css": "^1.1.2",
     "@warp-ds/icons": "^1.1.0",
     "@warp-ds/uno": "^1.1.0",
-    "@warp-ds/vue": "^1.1.1",
+    "@warp-ds/vue": "^1.1.2-next.2",
     "markdown-it": "^13.0.1",
     "sass": "^1.62.1",
     "unocss": "^0.55.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@warp-ds/css": "^1.3.0",
     "@warp-ds/icons": "^1.1.1",
     "@warp-ds/uno": "^1.1.0",
-    "@warp-ds/vue": "^1.1.1",
+    "@warp-ds/vue": "^1.2.0",
     "markdown-it": "^13.0.2",
     "sass": "^1.69.5",
     "unocss": "^0.57.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@warp-ds/css": "^1.3.0",
     "@warp-ds/icons": "^1.1.1",
     "@warp-ds/uno": "^1.1.0",
-    "@warp-ds/vue": "^1.2.0-next.3",
+    "@warp-ds/vue": "^1.1.1",
     "markdown-it": "^13.0.2",
     "sass": "^1.69.5",
     "unocss": "^0.57.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@warp-ds/css": "^1.3.0",
     "@warp-ds/icons": "^1.1.1",
     "@warp-ds/uno": "^1.1.0",
-    "@warp-ds/vue": "^1.1.1",
+    "@warp-ds/vue": "^1.2.0-next.3",
     "markdown-it": "^13.0.2",
     "sass": "^1.69.5",
     "unocss": "^0.57.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@warp-ds/css": "^1.1.2",
     "@warp-ds/icons": "^1.1.0",
     "@warp-ds/uno": "^1.1.0",
-    "@warp-ds/vue": "^1.1.2-next.2",
+    "@warp-ds/vue": "^1.1.2-next.3",
     "markdown-it": "^13.0.1",
     "sass": "^1.62.1",
     "unocss": "^0.55.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ devDependencies:
     specifier: ^1.1.0
     version: 1.1.0
   '@warp-ds/vue':
-    specifier: ^1.1.1
-    version: 1.1.1
+    specifier: ^1.1.2-next.2
+    version: 1.1.2-next.2
   markdown-it:
     specifier: ^13.0.1
     version: 13.0.1
@@ -1039,8 +1039,8 @@ packages:
       '@unocss/preset-mini': 0.52.7
     dev: true
 
-  /@warp-ds/vue@1.1.1:
-    resolution: {integrity: sha512-Q+c5FJwwVJt7qUf4pFCrrQCKv3KJdBoUhBw/j61iFE6woka9Z448PCFQ8NAPpmMJlvRP6wo3Ffsku347ZRpVUg==}
+  /@warp-ds/vue@1.1.2-next.2:
+    resolution: {integrity: sha512-ZUDYPNzno/0LybXX+udQP7I8aB4L8+oeKTDad+TNre0MZUoM7zI1/FzF6oOQowwBoCMlqrzfuh53IWIUK0mhhg==}
     dependencies:
       '@floating-ui/dom': 1.5.1
       '@lingui/core': 4.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ devDependencies:
     specifier: ^1.1.0
     version: 1.1.0
   '@warp-ds/vue':
-    specifier: ^1.1.2-next.2
-    version: 1.1.2-next.2
+    specifier: ^1.1.2-next.3
+    version: 1.1.2-next.3
   markdown-it:
     specifier: ^13.0.1
     version: 13.0.1
@@ -1039,8 +1039,8 @@ packages:
       '@unocss/preset-mini': 0.52.7
     dev: true
 
-  /@warp-ds/vue@1.1.2-next.2:
-    resolution: {integrity: sha512-ZUDYPNzno/0LybXX+udQP7I8aB4L8+oeKTDad+TNre0MZUoM7zI1/FzF6oOQowwBoCMlqrzfuh53IWIUK0mhhg==}
+  /@warp-ds/vue@1.1.2-next.3:
+    resolution: {integrity: sha512-4KTm1ksro1/C4DhyBGiCOU78M+aTW3JaZG/Z4Ct7jBXEK4COrEH+Y0C02IwpoLzLtKFJUu4/tB9yGCgY+0tiCw==}
     dependencies:
       '@floating-ui/dom': 1.5.1
       '@lingui/core': 4.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ devDependencies:
     specifier: ^1.1.0
     version: 1.1.0
   '@warp-ds/vue':
-    specifier: ^1.2.0-next.3
-    version: 1.2.0-next.3
+    specifier: ^1.1.1
+    version: 1.1.1
   markdown-it:
     specifier: ^13.0.2
     version: 13.0.2
@@ -1069,8 +1069,8 @@ packages:
       '@unocss/preset-mini': 0.52.7
     dev: true
 
-  /@warp-ds/vue@1.2.0-next.3:
-    resolution: {integrity: sha512-crSR5oqwvb0yhKevZyU7pzkBwLqdPLFyHcUb76969z8UcAmSS/DqxAaOjuQ+RkfhzWsr6TZBoiEAOJx+TeeYUQ==}
+  /@warp-ds/vue@1.1.1:
+    resolution: {integrity: sha512-Q+c5FJwwVJt7qUf4pFCrrQCKv3KJdBoUhBw/j61iFE6woka9Z448PCFQ8NAPpmMJlvRP6wo3Ffsku347ZRpVUg==}
     dependencies:
       '@floating-ui/dom': 1.5.3
       '@lingui/core': 4.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ devDependencies:
     specifier: ^1.1.0
     version: 1.1.0
   '@warp-ds/vue':
-    specifier: ^1.1.1
-    version: 1.1.1
+    specifier: ^1.2.0
+    version: 1.2.0
   markdown-it:
     specifier: ^13.0.2
     version: 13.0.2
@@ -1069,8 +1069,8 @@ packages:
       '@unocss/preset-mini': 0.52.7
     dev: true
 
-  /@warp-ds/vue@1.1.1:
-    resolution: {integrity: sha512-Q+c5FJwwVJt7qUf4pFCrrQCKv3KJdBoUhBw/j61iFE6woka9Z448PCFQ8NAPpmMJlvRP6wo3Ffsku347ZRpVUg==}
+  /@warp-ds/vue@1.2.0:
+    resolution: {integrity: sha512-2rTJVKVr9vcZP1KozVpRj6OaYD5DUlTRh7pMJTTRvGcFtPIPIKFhbol83YHWaw1OxY0C/Bvfaxjux4QSSp5RWA==}
     dependencies:
       '@floating-ui/dom': 1.5.3
       '@lingui/core': 4.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ devDependencies:
     specifier: ^1.1.0
     version: 1.1.0
   '@warp-ds/vue':
-    specifier: ^1.1.1
-    version: 1.1.1
+    specifier: ^1.2.0-next.3
+    version: 1.2.0-next.3
   markdown-it:
     specifier: ^13.0.2
     version: 13.0.2
@@ -1069,8 +1069,8 @@ packages:
       '@unocss/preset-mini': 0.52.7
     dev: true
 
-  /@warp-ds/vue@1.1.1:
-    resolution: {integrity: sha512-Q+c5FJwwVJt7qUf4pFCrrQCKv3KJdBoUhBw/j61iFE6woka9Z448PCFQ8NAPpmMJlvRP6wo3Ffsku347ZRpVUg==}
+  /@warp-ds/vue@1.2.0-next.3:
+    resolution: {integrity: sha512-crSR5oqwvb0yhKevZyU7pzkBwLqdPLFyHcUb76969z8UcAmSS/DqxAaOjuQ+RkfhzWsr6TZBoiEAOJx+TeeYUQ==}
     dependencies:
       '@floating-ui/dom': 1.5.3
       '@lingui/core': 4.5.0


### PR DESCRIPTION
Update attention documentation:
- Refactor Example.vue for callout, tooltip and popover-examples according to comments from a11y-team
- Add `role` + `aria-label`-props under props-list for react and vue
- Add accessibility-section for react and vue and explain the usage of `role` and `aria-label`-props.
- Update elements' accessibility-section