### PR TITLE
docs: add missing aria-labels to button affixes

### DIFF
--- a/docs/components/textfield/Example.vue
+++ b/docs/components/textfield/Example.vue
@@ -30,13 +30,13 @@ const handleClear = () => {
     <div>
       <h3 class="h4">Invalid</h3>
       <w-textfield label="A label" #suffix invalid required v-model="inputModel">
-        <w-affix suffix clear @click="handleClear" />
+        <w-affix suffix clear aria-label="Clear text" @click="handleClear" />
       </w-textfield>
     </div>
     <div>
       <h3 class="h4">Suffix + Prefix</h3>
       <w-textfield label="A label" #prefix #suffix v-model="inputModel">
-        <w-affix suffix clear @click="handleClear" />
+        <w-affix suffix clear aria-label="Clear text" @click="handleClear" />
         <w-affix prefix label="kr" />
       </w-textfield>
     </div>

--- a/docs/components/textfield/elements.md
+++ b/docs/components/textfield/elements.md
@@ -59,7 +59,7 @@ You must specify which slot to set the affix into (either prefix or suffix).
 ```html
 <w-textfield label="Price" placeholder="1 000 000">
   <w-affix slot="prefix" label="kr"></w-affix>
-  <w-affix slot="suffix" search></w-affix>
+  <w-affix slot="suffix" search aria-label="Search"></w-affix>
 </w-textfield>
 ```
 <api-table type=elements component="Affix" />

--- a/docs/components/textfield/react.md
+++ b/docs/components/textfield/react.md
@@ -114,13 +114,13 @@ Then you include it as a child of TextField component and pass the appropiate pr
 
 ```jsx
 <TextField>
-  <Affix suffix clear onClick={() => alert('clear')} />
+  <Affix suffix clear aria-label="Clear text" onClick={() => alert('clear')} />
 </TextField>
 ```
 
 ```jsx
 <TextField>
-  <Affix suffix search onClick={() => alert('search')} />
+  <Affix suffix search aria-label="Search" onClick={() => alert('search')} />
 </TextField>
 ```
 
@@ -129,7 +129,7 @@ You can also use both a prefix and suffix
 ```jsx
 <TextField>
   <Affix prefix label="kr" />
-  <Affix suffix search onClick={() => alert('search')} />
+  <Affix suffix search aria-label="Search" onClick={() => alert('search')} />
 </TextField>
 ```
 


### PR DESCRIPTION
Fixes [WARP-337](https://nmp-jira.atlassian.net/browse/WARP-337)