### PR TITLE
docs: add recommendation to not combine link + href when using warp-button

### DIFF
--- a/docs/api-table.js
+++ b/docs/api-table.js
@@ -176,7 +176,7 @@ export const react = {
         'link',
         'boolean',
         'false',
-        'Set the button to look like a link. Can be combined with `small`.',
+        'Set the button to look like a link. Can be combined with `small`. Should not be combined with `href`',
       ],
       [
         'pill',
@@ -194,7 +194,7 @@ export const react = {
         'href',
         'string',
         '',
-        'Set the href for the location where clicking the button will take you to. Uses an a tag instead of a button tag for the underlying implementation.',
+        'Set the href for the location where clicking the button will take you to. Uses an a tag instead of a button tag for the underlying implementation. Should not be combined with `link`',
       ],
       [
         'target',
@@ -892,7 +892,7 @@ export const vue = {
         'href',
         'string',
         '',
-        'When set, an anchor tag will be used instead of a button',
+        'When set, an anchor tag will be used instead of a button. Should not be combined with variant `link`',
       ],
       [
         'type',
@@ -1336,7 +1336,7 @@ export const elements = {
         'href',
         'string',
         '',
-        'Set the href for the location where clicking the button will take you to. Uses an a tag instead of a button tag for the underlying implementation.',
+        'Set the href for the location where clicking the button will take you to. Uses an a tag instead of a button tag for the underlying implementation. Should not be combined with variant `link`',
       ],
       [
         'target',

--- a/docs/components/buttons/elements.md
+++ b/docs/components/buttons/elements.md
@@ -60,10 +60,18 @@ By default, buttons have a visible stroke and fill. Quiet buttons do not have th
 ```
 
 #### Link
-Buttons will be rendered as an anchor (a tag) if they use an href attribute.
+Buttons will be rendered as an anchor (a tag) if they use the `href` attribute.
 ```html
 <w-button href="https://google.no">Button as anchor</w-button>
 ```
+
+But if you need a button to look like a link, use the `link` variant.
+
+```html
+<w-button variant="link">Link button</w-button>
+```
+However, it is not recommended to use the `link` variant in combination with the `href` attribute. 
+If there is a need to have an anchor (a tag) that should still look like a link, the recommendation is to instead use the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a" target="_blank" rel="noopener">`<a>` HTML element</a>. 
 
 #### Loading state
 To show the user that the action they triggered has begun, buttons have an in progress or loading state.

--- a/docs/components/buttons/react.md
+++ b/docs/components/buttons/react.md
@@ -76,6 +76,9 @@ But if you need a button to look like a link, use the `link` property.
 <Button link>Link</Button>
 ```
 
+However, it is not recommended to use `link` property in combination with the `href` attribute. 
+If there is a need to have an anchor (a tag) that should still look like a link, the recommendation is to instead use the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a" target="_blank" rel="noopener">`<a>` HTML element</a>. 
+
 #### Disabled
 
 Disabled is an anti-pattern and is not supported. There will always be users who


### PR DESCRIPTION
This fix is related to Jira ticket [WARP-382](https://nmp-jira.atlassian.net/browse/WARP-382).

After discussions we have decided to not recommend using button with both link and href-props activated. We instead recommend the use of an anchor-tag.

- Update documentation for button to not recommend combining link and href-props.