### PR TITLE
docs: update icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@warp-ds/css": "^1.3.0",
-    "@warp-ds/icons": "^1.1.1",
+    "@warp-ds/icons": "^1.3.0",
     "@warp-ds/uno": "^1.1.0",
     "@warp-ds/vue": "^1.2.0",
     "markdown-it": "^13.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ devDependencies:
     specifier: ^1.3.0
     version: 1.3.0
   '@warp-ds/icons':
-    specifier: ^1.1.1
-    version: 1.1.1
+    specifier: ^1.3.0
+    version: 1.3.0
   '@warp-ds/uno':
     specifier: ^1.1.0
     version: 1.1.0
@@ -1049,8 +1049,8 @@ packages:
       '@lingui/core': 4.5.0
     dev: true
 
-  /@warp-ds/icons@1.1.1:
-    resolution: {integrity: sha512-XUDIxqHVbqLgoQHgpCSCgchCKwNUdsBz3siEcyE9/gRitEN30vbEReKgU2sIBoco8YCgKo0MuebA1+CCvfqFNg==}
+  /@warp-ds/icons@1.3.0:
+    resolution: {integrity: sha512-YlP8p3ONQmpx8114xhySN+Rx+6hkWETXztvl3sw6MdGsXgXhNhO9pKs8x2MIx3K+R15vBfV8dt8fdqGPmFgL6w==}
     dependencies:
       '@lingui/core': 4.5.0
     dev: true


### PR DESCRIPTION
Update tech-docs with new icons:

Several existing icons in size 16px:
- TaskList
- CircleUser
- Ads
- CreditCard
- LockShield
- User
- Bell
- Building
- Door
- Camera
- BankId

New Fiks Ferdig icons:
- Shoes
- Vacuum
- Drawer
- Mixer
- (TorgetDelivery has been horizontally flipped)

Updated marketplace icons:
- Airplane
- Cabin
- Car
- CarRent
- Economy
- Job
- Market
- Motorcycle
- Nybrukt
- RealEstate
- Sailboat

Updated twitter icon