### PR TITLE
fix: align TS icon snipped with icons v1.3

### DIFF
--- a/docs/components/icons/elements.md
+++ b/docs/components/icons/elements.md
@@ -41,6 +41,6 @@ You can define an 'icons.d.ts' file in your repo and export the types bundled wi
 
 ```
 declare module '@warp-ds/icons/elements' {
-    export * from '@warp-ds/icons/dist/types/elements'
+    export * from '@warp-ds/icons/dist/elements/index.d.ts'
 }
 ```

--- a/docs/components/icons/react.md
+++ b/docs/components/icons/react.md
@@ -20,6 +20,6 @@ You can define an 'icons.d.ts' file in your repo and export the types bundled wi
 
 ```
 declare module '@warp-ds/icons/react' {
-    export * from '@warp-ds/icons/dist/types/react'
+    export * from '@warp-ds/icons/dist/react/index.d.ts'
 }
 ```

--- a/docs/components/icons/vue.md
+++ b/docs/components/icons/vue.md
@@ -12,7 +12,7 @@ import { IconBag16 } from '@warp-ds/icons/vue';
 
 ### Colors
 
-The color of the icon will default to `currentColor`. 
+The color of the icon will default to `currentColor`.
 Colors can be changed using [semantic color classes for icons](https://warp-ds.github.io/css-docs/icon-color#icon-color).
 
 ### Typescript support
@@ -21,6 +21,6 @@ You can define an 'icons.d.ts' file in your repo and export the types bundled wi
 
 ```
 declare module '@warp-ds/icons/vue' {
-    export * from '@warp-ds/icons/dist/types/vue'
+    export * from '@warp-ds/icons/dist/vue/index.d.ts'
 }
 ```


### PR DESCRIPTION
Looks like `@warp-ds/icons` v1.3 had a breaking change for TS since the types moved? This aligns the docs with that breaking change.