### PR TITLE
Update our docs for icons types

### DIFF
--- a/docs/components/icons/elements.md
+++ b/docs/components/icons/elements.md
@@ -27,6 +27,8 @@ import "@warp-ds/icons/elements/alert-16";
 <w-icon-bag-16></w-icon-bag-16>
 ```
 
+Check out exact imports below in our Examples section
+
 ### Colors
 The color of the icon will default to `currentColor`.
 Colors can be changed using [semantic color classes for icons](https://warp-ds.github.io/css-docs/icon-color#icon-color).
@@ -34,13 +36,3 @@ Colors can be changed using [semantic color classes for icons](https://warp-ds.g
 ### Fabric to WARP
 
 We have changed the naming for these icons, so the old icons in Fabric were `f-icon-bag16` while the new icons in WARP is named as `w-icon-bag-16`
-
-### Typescript support
-
-You can define an 'icons.d.ts' file in your repo and export the types bundled with the package for the correct namespace. Eg for Elements:
-
-```
-declare module '@warp-ds/icons/elements' {
-    export * from '@warp-ds/icons/dist/types/elements'
-}
-```

--- a/docs/components/icons/index.md
+++ b/docs/components/icons/index.md
@@ -10,10 +10,6 @@ Warp's icon set is designed to help users understand actions, information and dr
 
 <components-status react='released' vue='released' elements='released' />
 
-## Usage
-
-<component-design-guidelines name="Warp - Components / Icons" link="https://www.figma.com/file/yEx16ew6S0Xgd579dN4hsM/Warp---Icons?type=design&node-id=6011-1442&mode=design&t=zY5N398IPei2z89J-0" />
-
 <component-questions />
 
 ## Frameworks
@@ -29,6 +25,11 @@ Warp's icon set is designed to help users understand actions, information and dr
     <elements />
   </template>
 </tabs-content>
+
+## Typescript support
+
+Starting from @warp-ds/icons@1.3.0, We are fully typescript compliant. You'll need to switch to module & moduleResolution as `NodeNext`. You can read more about it [here](https://www.typescriptlang.org/docs/handbook/modules/reference.html#node16-nodenext)
+
 
 ## Setup
 

--- a/docs/components/icons/react.md
+++ b/docs/components/icons/react.md
@@ -10,16 +10,8 @@ import { IconBag16 } from '@warp-ds/icons/react';
 <IconBag16 />
 ```
 
+Check out exact imports below in our Examples section
+
 ### Colors
 The color of the icon will default to `currentColor`.
 Colors can be changed using [semantic color classes for icons](https://warp-ds.github.io/css-docs/icon-color#icon-color).
-
-### Typescript support
-
-You can define an 'icons.d.ts' file in your repo and export the types bundled with the package for the correct namespace. Eg for React:
-
-```
-declare module '@warp-ds/icons/react' {
-    export * from '@warp-ds/icons/dist/types/react'
-}
-```

--- a/docs/components/icons/vue.md
+++ b/docs/components/icons/vue.md
@@ -10,17 +10,9 @@ import { IconBag16 } from '@warp-ds/icons/vue';
 <icon-bag-16 />
 ```
 
+Check out exact imports below in our Examples section
+
 ### Colors
 
 The color of the icon will default to `currentColor`. 
 Colors can be changed using [semantic color classes for icons](https://warp-ds.github.io/css-docs/icon-color#icon-color).
-
-### Typescript support
-
-You can define an 'icons.d.ts' file in your repo and export the types bundled with the package for the correct namespace. Eg for Vue:
-
-```
-declare module '@warp-ds/icons/vue' {
-    export * from '@warp-ds/icons/dist/types/vue'
-}
-```


### PR DESCRIPTION
This PR contains:
- Updating tech docs for typescript usage of Icons
- Removing Link to Figma
