### PR TITLE
fix(textfield): update @warp-ds/vue and add affix examples

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -11,7 +11,7 @@ const docsClasses = ['text-12', 'font-bold', 'space-y-24', 'space-x-24','mt-16',
 'top-12','left-12','bg-aqua-200','text-aqua-900','p-4','rounded-4','p-16','font-bold','my-8', 'gap-10', 'w-100',
 'max-w-screen-xl', 'mx-auto', 'px-32', 's-bg-active', 'rounded-8', 'p-24', 'mb-24', 'grid', 'gap-24', 'mx-auto', 'mb-8',
 's-bg', 'rounded-4', 'h-56', 'flex', 'items-center', 'justify-center', 'flex-col', 's-icon', 'grid-cols-minmax-100px',
-'last:ml-auto!',];
+'last:ml-auto!','[--w-prefix-width:56px]'];
 
 export default defineConfig({
   lang: 'en-US',

--- a/docs/components/textfield/Example.vue
+++ b/docs/components/textfield/Example.vue
@@ -35,9 +35,9 @@ const handleClear = () => {
     </div>
     <div>
       <h3 class="h4">Suffix + Prefix</h3>
-      <w-textfield label="A label" #prefix #suffix v-model="inputModel">
-        <w-affix suffix clear aria-label="Clear text" @click="handleClear" />
-        <w-affix prefix label="kr" />
+      <w-textfield label="A label" v-model="inputModel">
+        <template #prefix><w-affix prefix label="kr" /></template>
+        <template #suffix><w-affix suffix clear aria-label="Clear text" @click="handleClear" /></template>
       </w-textfield>
     </div>
   </div>

--- a/docs/components/textfield/Example.vue
+++ b/docs/components/textfield/Example.vue
@@ -40,5 +40,11 @@ const handleClear = () => {
         <template #suffix><w-affix suffix clear aria-label="Clear text" @click="handleClear" /></template>
       </w-textfield>
     </div>
+    <div>
+      <h3 class="h4">Wider Prefix</h3>
+      <w-textfield label="Price in kroner" v-model="inputModel" class="[--w-prefix-width:56px]" #prefix placeholder="1 000 000">
+        <w-affix prefix label="kroner" />
+      </w-textfield>
+    </div>
   </div>
 </template>

--- a/docs/components/textfield/elements.md
+++ b/docs/components/textfield/elements.md
@@ -54,6 +54,15 @@ You must specify which slot to set the affix into (either prefix or suffix).
 </w-textfield>
 ```
 
+> For prefixes wider than 40px, push the input further to the right by setting a `--w-prefix-width` value on the w-textfield element.
+> This will increase left padding of its input element. This value needs to be hardcoded until we find a more robust solution.
+
+```html
+<w-textfield class="[--w-prefix-width:56px]" label="Price in kroner">
+  <w-affix slot="prefix" label="kroner"></w-affix>
+</w-textfield>
+```
+
 > You can also use both a prefix and suffix
 
 ```html

--- a/docs/components/textfield/react.md
+++ b/docs/components/textfield/react.md
@@ -124,6 +124,14 @@ Then you include it as a child of TextField component and pass the appropiate pr
 </TextField>
 ```
 
+For prefixes wider than 40px, push the input further to the right by setting a `--w-prefix-width` value on the TextField component. This will increase left padding of its input element. This value needs to be hardcoded until we find a more robust solution.
+
+```jsx
+<TextField className="[--w-prefix-width:56px]" label="Price in kroner">
+  <Affix prefix label="kroner" />
+</TextField>
+```
+
 You can also use both a prefix and suffix
 
 ```jsx

--- a/docs/components/textfield/vue.md
+++ b/docs/components/textfield/vue.md
@@ -39,9 +39,49 @@ export default {
     provide('Cleave', Cleave)
   }
 }
-
 // or install app-wide by using the provide method on app
 app.provide('Cleave', Cleave)
+```
+
+#### Affixes
+
+If you wish to use an affix you must first import the wAffix component
+
+```js
+import { wAffix } from '@warp-ds/vue';
+```
+
+Then you include it as a child to w-textfield and pass the appropiate props.
+You must specify which slot to set the affix into (either prefix or suffix).
+
+> Suffix
+```html
+<w-textfield #suffix v-model="inputModel" label="Search for items">
+  <w-affix suffix search aria-label="Search" @click="handleSearch"/>
+</w-textfield>
+```
+
+> Prefix
+```html
+<w-textfield #prefix v-model="inputModel" label="Price">
+  <w-affix prefix label="kr"/>
+</w-textfield>
+```
+
+> For prefixes wider than 40px, push the input further to the right by setting a `--w-prefix-width` value on the w-textfield component.
+> This will increase left padding of its input element. This value needs to be hardcoded until we find a more robust solution.
+```html
+<w-textfield class="[--w-prefix-width:56px]" #prefix label="Price in kroner">
+  <w-affix prefix label="kroner"></w-affix>
+</w-textfield>
+```
+
+> You can also use both a prefix and suffix
+```html
+<w-textfield v-model="inputModel" label="Price">
+  <template #prefix><w-affix prefix label="kr" /></template>
+  <template #suffix><w-affix suffix clear aria-label="Clear text" @click="handleClear" /></template>
+</w-textfield>
 ```
 
 ### Validation

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@warp-ds/css": "^1.4.2",
     "@warp-ds/icons": "^1.3.0",
     "@warp-ds/uno": "^1.3.0",
-    "@warp-ds/vue": "^1.2.1",
+    "@warp-ds/vue": "^1.2.2",
     "decamelize": "^6.0.0",
     "markdown-it": "^13.0.2",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ devDependencies:
     specifier: ^1.3.0
     version: 1.3.0
   '@warp-ds/vue':
-    specifier: ^1.2.1
-    version: 1.2.1
+    specifier: ^1.2.2
+    version: 1.2.2
   decamelize:
     specifier: ^6.0.0
     version: 6.0.0
@@ -1055,12 +1055,6 @@ packages:
       '@warp-ds/uno': 1.3.0
     dev: true
 
-  /@warp-ds/icons@1.2.0:
-    resolution: {integrity: sha512-K8N9e08q3BEK6MwkH9AgTaHHuWy6tadsSEYa2kkfRKlKF6McHG5D/lTo/qDig6lz5TKBnBK2Qp+UnB+f16LsvQ==}
-    dependencies:
-      '@lingui/core': 4.5.0
-    dev: true
-
   /@warp-ds/icons@1.3.0:
     resolution: {integrity: sha512-YlP8p3ONQmpx8114xhySN+Rx+6hkWETXztvl3sw6MdGsXgXhNhO9pKs8x2MIx3K+R15vBfV8dt8fdqGPmFgL6w==}
     dependencies:
@@ -1082,14 +1076,14 @@ packages:
       '@unocss/rule-utils': 0.57.7
     dev: true
 
-  /@warp-ds/vue@1.2.1:
-    resolution: {integrity: sha512-fXmIxD2poD7btAfb87UE+qB+crgnQusjKuhgUlM6l/blFrrl/nJEU/wNtvGIEJ+9liObl/1xPNjz6uLf1iIB4g==}
+  /@warp-ds/vue@1.2.2:
+    resolution: {integrity: sha512-ZktIR488juwUt0JN02OA7BY3M7HjxAN5+ht8UuNpR1d5G4LWPg2PqkoLJ6ocMX9i2lRxpx777N4u5osjwTGe7g==}
     dependencies:
       '@floating-ui/dom': 1.5.3
       '@lingui/core': 4.5.0
       '@warp-ds/core': 1.0.2
       '@warp-ds/css': 1.4.2
-      '@warp-ds/icons': 1.2.0
+      '@warp-ds/icons': 1.3.0
       '@warp-ds/uno': 1.3.0
       create-v-model: 2.2.0
       dom-focus-lock: 1.1.0


### PR DESCRIPTION
**This PR includes the following changes:**
- update @warp-ds/vue to 1.2.2
- update Text Field examples in React and Element to show how wider prefixes can be handled
- add a corresponding Affixes section to Vue Text Field docs

Vue:
<img width="565" alt="Screenshot 2023-11-30 at 15 01 30" src="https://github.com/warp-ds/tech-docs/assets/41303231/27735bad-a6bd-44cc-91bf-6458a9180e07">

React:
<img width="567" alt="Screenshot 2023-11-30 at 15 01 43" src="https://github.com/warp-ds/tech-docs/assets/41303231/467e0013-5fa3-4519-a0c0-ede062c905dc">

Elements:
<img width="560" alt="Screenshot 2023-11-30 at 15 01 19" src="https://github.com/warp-ds/tech-docs/assets/41303231/1dd85e23-395f-4243-bfcf-7c59dced2ed1">

