### PR TITLE
chore: update @warp-ds/icons to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@warp-ds/css": "^1.4.2",
-    "@warp-ds/icons": "^1.3.0",
+    "@warp-ds/icons": "^1.4.0",
     "@warp-ds/uno": "^1.3.0",
     "@warp-ds/vue": "^1.2.2",
     "decamelize": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ devDependencies:
     specifier: ^1.4.2
     version: 1.4.2
   '@warp-ds/icons':
-    specifier: ^1.3.0
-    version: 1.3.0
+    specifier: ^1.4.0
+    version: 1.4.0
   '@warp-ds/uno':
     specifier: ^1.3.0
     version: 1.3.0
@@ -1057,6 +1057,12 @@ packages:
 
   /@warp-ds/icons@1.3.0:
     resolution: {integrity: sha512-YlP8p3ONQmpx8114xhySN+Rx+6hkWETXztvl3sw6MdGsXgXhNhO9pKs8x2MIx3K+R15vBfV8dt8fdqGPmFgL6w==}
+    dependencies:
+      '@lingui/core': 4.5.0
+    dev: true
+
+  /@warp-ds/icons@1.4.0:
+    resolution: {integrity: sha512-CC4LlDUlSa65/ts4REDk8hVC3vY+IA6D6mhTFYg31WpOf8KwfzNY4QnEnXdzbL/1WUFU+fmUSejgqbwI8nnpVw==}
     dependencies:
       '@lingui/core': 4.5.0
     dev: true


### PR DESCRIPTION
Fixes [WARP-405](https://nmp-jira.atlassian.net/browse/WARP-405)

Release notes for @warp-ds/icons@1.4.0: https://github.com/warp-ds/icons/releases/tag/v1.4.0