### PR TITLE
fix: move button before modal in the DOM

### DIFF
--- a/docs/components/modal/Example.vue
+++ b/docs/components/modal/Example.vue
@@ -18,6 +18,7 @@ const changeHeight = () => heightToggle.value = !heightToggle.value
   <div class="component">
     <h3 class="h4">Default</h3>
     <div class="flex gap-10">
+      <w-button utility @click="showModal = true">Show modal</w-button>
       <w-modal title="Hello Warp!" :style="demoStyles" :left="showLeft" :right="{ 'aria-label': 'Close' }" @dismiss="showModal = false" v-model="showModal" @right="showModal = false">
         <div class="space-x-8">
           <w-button utility @click="changeHeight" small class="mb-32">Modify height</w-button>
@@ -35,7 +36,6 @@ const changeHeight = () => heightToggle.value = !heightToggle.value
           <w-button primary @click="showModal = false">Click me</w-button>
         </template>
       </w-modal>
-      <w-button utility @click="showModal = true">Show modal</w-button>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Fixes [WARP-408](https://nmp-jira.atlassian.net/browse/WARP-408)

This should fix an issue where tabbing inside an open modal would at some point reach a button in the back.

Not sure why changing order of elements in the DOM fixes it. I couldn't reproduce the issue locally in @warp-ds/vue, so it feels like it's not necessarily something wrong with the Modal component itself.

Before:
![gif showing wrong tabbing order of interactive elements](https://github.com/warp-ds/tech-docs/assets/41303231/2ad61f02-72e2-403d-a903-77b06769f21a)

After:
![gif showing correct tabbing order](https://github.com/warp-ds/tech-docs/assets/41303231/0dacedae-426f-4e67-883b-76106c42c1f2)
