### PR TITLE
chore: remove Blocket from ThemeSwitcher

### DIFF
--- a/docs/.vitepress/ThemeSwitcher.vue
+++ b/docs/.vitepress/ThemeSwitcher.vue
@@ -3,7 +3,6 @@ import { computed } from 'vue';
 
 const themes = {
   'Finn': 'finn-no',
-  'Blocket': 'blocket-se',
   'Tori': 'tori-fi'
 };
 

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -64,13 +64,6 @@ export default defineConfig({
         rel: 'stylesheet',
         href: 'https://assets.finn.no/pkg/@warp-ds/fonts/v1/tori-fi.css'
       }
-    ],
-    [
-      'link',
-      {
-        rel: 'stylesheet',
-        href: 'https://assets.finn.no/pkg/@warp-ds/fonts/v1/blocket-se.css'
-      }
     ]
   ],
   themeConfig: {


### PR DESCRIPTION
Blocket brand colors are not yet supported in Warp (we've only copied Finn tokens there for testing purposes). We shouldn't include Blocket in the theme switcher until correct colors are displayed.
<img width="712" alt="Screenshot showing only Finn and Tori in the theme switching select" src="https://github.com/warp-ds/tech-docs/assets/41303231/7610ff87-bd25-4adb-807e-eb124c0cbc67">
