### PR TITLE
fix: update support of warp icons in migration docs

### DIFF
--- a/docs/migration/developers/index.md
+++ b/docs/migration/developers/index.md
@@ -24,7 +24,7 @@ If it is necessary to include both libraries, it is recommended to encapsulate o
 
 ### Icons
 
-Warp does not currently support icons. Until Warp icons being available, continue import the icons from Fabric.
+Warp now supports icons, and it is no longer necessary to continue importing the icons from Fabric. See further information and icons usage on our [icons page](https://warp-ds.github.io/tech-docs/components/icons/).
 
 ### Colours
 


### PR DESCRIPTION
Fixes JIRA ticket: [WARP-420](https://nmp-jira.atlassian.net/browse/WARP-420)

- Update migration docs to inform that Warp now supports icons. 