### PR TITLE
fix: add info to remove preset-migrate once migrated

### DIFF
--- a/docs/migration/developers/index.md
+++ b/docs/migration/developers/index.md
@@ -36,7 +36,7 @@ The migration plugin is available to use to detect all deprecated CSS classes an
 
 #### Install the plugin
 :::info
-Do not forget to uninstall the plugin one the migration is complete.
+Do not forget to uninstall the plugin once the migration is complete.
 :::
 
 ```shell

--- a/docs/migration/developers/index.md
+++ b/docs/migration/developers/index.md
@@ -35,6 +35,9 @@ Warp utilises a system of coloring border, text, background and icons using sema
 The migration plugin is available to use to detect all deprecated CSS classes and provide warnings with useful hints.
 
 #### Install the plugin
+:::info
+Do not forget to uninstall the plugin one the migration is complete.
+:::
 
 ```shell
 npm install @warp-ds/preset-migrate --save-dev


### PR DESCRIPTION
Fixes JIRA-ticket: [WARP-421](https://nmp-jira.atlassian.net/browse/WARP-421)

- Added info-section to inform user to remember to uninstall the preset-migrate-plugin once they are finished with migrating.