### PR TITLE
fix: add missing button examples for utility quiet and link

### DIFF
--- a/docs/.vitepress/ApiTable.vue
+++ b/docs/.vitepress/ApiTable.vue
@@ -28,7 +28,7 @@ const data = computed(() => apiTable[props.type || 'react'][props.component]);
     </div>
     <div v-if="data.variants?.length">
       <component :is="`h${headerLevel}`">Variants</component>
-      <other-table :headers="['main', 'combination']" :data="data.variants" />
+      <other-table :headers="['main', 'combination', 'notes']" :data="data.variants" />
     </div>
     <div v-if="data.slots?.length">
       <component :is="`h${headerLevel}`">Slots</component>

--- a/docs/api-table.js
+++ b/docs/api-table.js
@@ -158,7 +158,7 @@ export const react = {
         'utility',
         'boolean',
         'false',
-        'Set the button to be a utility style button. Can be combined with `small`.',
+        'Set the button to be a utility style button. Can be combined with `small` and `quiet`.',
       ],
       [
         'quiet',
@@ -182,7 +182,7 @@ export const react = {
         'pill',
         'boolean',
         'false',
-        'Set the button to look like a pill style button.',
+        'Set the button to look like a pill style button. @deprecated use `utility` together with `quiet` instead.',
       ],
       [
         'loading',
@@ -908,13 +908,13 @@ export const vue = {
       ],
     ],
     variants: [
-      ['primary', 'quiet, small, loading'],
-      ['secondary', 'quiet, small, loading'],
-      ['negative', 'quiet, small, loading'],
-      ['link', 'small'],
-      ['utility', 'small, loading'],
-      ['pill', ''],
-    ],
+      ['primary', 'quiet, small, loading', ''],
+      ['secondary', 'quiet, small, loading', ''],
+      ['negative', 'quiet, small, loading', ''],
+      ['link', 'small', ''],
+      ['utility', 'small, loading, quiet', ''],
+      ['pill', '', '@deprecated use `utility` together with `quiet`instead.'],
+    ]
   },
   ButtonGroup: {
     required: [],
@@ -1325,7 +1325,7 @@ export const elements = {
       ],
       [
         'variant',
-        '"primary" | "secondary" | "negative" | "utility" | "link" | "pill"',
+        '"primary" | "secondary" | "negative" | "utility" | "link"',
         'secondary',
         '',
       ],

--- a/docs/api-table.js
+++ b/docs/api-table.js
@@ -913,7 +913,7 @@ export const vue = {
       ['negative', 'quiet, small, loading', ''],
       ['link', 'small', ''],
       ['utility', 'small, loading, quiet', ''],
-      ['pill', '', '@deprecated use `utility` together with `quiet`instead.'],
+      ['pill', '', '@deprecated use `utility` together with `quiet` instead.'],
     ]
   },
   ButtonGroup: {

--- a/docs/components/buttons/Example.vue
+++ b/docs/components/buttons/Example.vue
@@ -11,6 +11,9 @@
     <w-button secondary quiet>Secondary Quiet</w-button>
     <w-button negative>Negative</w-button>
     <w-button negative quiet>Negative Quiet</w-button>
+    <w-button pill>Pill</w-button>
+    <w-button pill loading>Loading</w-button>
+    <w-button link>Link</w-button>
     <w-button full-width primary>Primary full width</w-button>
   </div>
 </template>

--- a/docs/components/buttons/Example.vue
+++ b/docs/components/buttons/Example.vue
@@ -1,5 +1,6 @@
 <script setup>
   import { wButton } from '@warp-ds/vue';
+  import IconShare16 from '@warp-ds/icons/vue/share-16';
 </script>
 
 <template>
@@ -11,8 +12,7 @@
     <w-button secondary quiet>Secondary Quiet</w-button>
     <w-button negative>Negative</w-button>
     <w-button negative quiet>Negative Quiet</w-button>
-    <w-button pill>Pill</w-button>
-    <w-button pill loading>Loading</w-button>
+    <w-button utility quiet><icon-share-16 /></w-button>
     <w-button link>Link</w-button>
     <w-button full-width primary>Primary full width</w-button>
   </div>

--- a/docs/components/buttons/elements.md
+++ b/docs/components/buttons/elements.md
@@ -36,19 +36,18 @@ The negative button is for emphasizing actions that can be destructive or have n
 <w-button variant="utility">Utility button</w-button>
 <w-button variant="utility" small>Utility button small</w-button>
 ```
+The `utility` variant combined with `quiet` replaces the deprecated `pill` variant.
+```html
+<w-button variant="utility" quiet="">
+  <w-icon-share-16></w-icon-share-16>
+</w-button>
+```
 
 #### Link
 
 ```html
 <w-button variant="link">Link button</w-button>
 <w-button variant="link" small>Link button small</w-button>
-```
-
-#### Pill
-
-```html
-<w-button variant="pill">💙</w-button>
-<w-button variant="pill" small>💙</w-button>
 ```
 
 #### Quiet

--- a/docs/components/buttons/react.md
+++ b/docs/components/buttons/react.md
@@ -56,10 +56,10 @@ Used for visual feedback that the action the user triggered is loading.
 <Button small>Small</Button>
 ```
 
-#### Pill
-
+#### Utility
+The `utility` button combined with `quiet` replaces the deprecated button `pill` prop.
 ```jsx example
-<Button pill>Pill</Button>
+<Button utility quiet><IconShare16 /></Button>
 ```
 
 #### Link

--- a/docs/migration/developers/index.md
+++ b/docs/migration/developers/index.md
@@ -35,7 +35,7 @@ Warp utilises a system of coloring border, text, background and icons using sema
 The migration plugin is available to use to detect all deprecated CSS classes and provide warnings with useful hints.
 
 #### Install the plugin
-:::info
+:::info Reminder
 Do not forget to uninstall the plugin once the migration is complete.
 :::
 


### PR DESCRIPTION
Fixes JIRA-ticket: [WARP-376](https://nmp-jira.atlassian.net/browse/WARP-376)

- Added examples for button variants:
  - utility quiet
  - link

- Replaced pill with utility quiet + informed that pill is now deprecated.
- Add missing title to info-section in migration docs

