### PR TITLE
chore: update icons to 1.5.0

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -12,7 +12,7 @@ const docsClasses = ['text-12', 'font-bold', 'space-y-24', 'space-x-24','mt-16',
 'max-w-screen-xl', 'mx-auto', 'px-32', 's-bg-active', 'rounded-8', 'p-24', 'mb-24', 'grid', 'gap-24', 'mx-auto', 'mb-8',
 's-bg', 'rounded-4', 'h-56', 'flex', 'items-center', 'justify-center', 'flex-col', 's-icon', 'grid-cols-minmax-100px',
 'last:ml-auto!','[--w-prefix-width:56px]', 'md:block', 'md:hidden', 's-bg-primary', 's-text-inverted', 's-text-link', 'text-display', 
-'t1', 't2', 't3', 't4', 't5', 't6', 'text-preamble', 'text-body', 'text-caption', 'text-detail'];
+'t1', 't2', 't3', 't4', 't5', 't6', 'text-preamble', 'text-body', 'text-caption', 'text-detail', 's-bg-inverted'];
 
 export default defineConfig({
   lang: 'en-US',

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -12,7 +12,8 @@ const docsClasses = ['text-12', 'font-bold', 'space-y-24', 'space-x-24','mt-16',
 'max-w-screen-xl', 'mx-auto', 'px-32', 's-bg-active', 'rounded-8', 'p-24', 'mb-24', 'grid', 'gap-24', 'mx-auto', 'mb-8',
 's-bg', 'rounded-4', 'h-56', 'flex', 'items-center', 'justify-center', 'flex-col', 's-icon', 'grid-cols-minmax-100px',
 'last:ml-auto!','[--w-prefix-width:56px]', 'md:block', 'md:hidden', 's-bg-primary', 's-text-inverted', 's-text-link', 'text-display', 
-'t1', 't2', 't3', 't4', 't5', 't6', 'text-preamble', 'text-body', 'text-caption', 'text-detail', 's-bg-inverted'];
+'t1', 't2', 't3', 't4', 't5', 't6', 'text-preamble', 'text-body', 'text-caption', 'text-detail', 's-bg-inverted', 'text-center', 's-text-negative',
+'flex-1'];
 
 export default defineConfig({
   lang: 'en-US',

--- a/docs/components/icons/Example.vue
+++ b/docs/components/icons/Example.vue
@@ -33,8 +33,8 @@ const deprecatedIcons = [
   { old: 'Paw32', new:'AnimalPaw' },
   { old: 'Car42', new: 'Minivan' },
   { old: 'TableInfo', new:'Info' },
-  { old: 'Honk', new:'HonkLight' },
-  { old: 'Nettbil', new:'NettbilLight' }
+  { old: 'Honk42', new:'HonkLight' },
+  { old: 'Nettbil42', new:'NettbilLight' }
 ]
 
 const isDeprecated = (iconName) => deprecatedIcons.find(icon => iconName.includes(icon.old)) ? true : false;

--- a/docs/components/icons/Example.vue
+++ b/docs/components/icons/Example.vue
@@ -5,6 +5,41 @@ import * as reactIcons from "@warp-ds/icons/react";
 import { wModal } from "@warp-ds/vue";
 import { ref } from "vue";
 
+const deprecatedIcons = [
+  { old: 'AlertWarning', new: 'WarningFilled' },
+  { old: 'BankId', new: 'BankIdNo' },
+  { old: 'BankIdent', new: 'CheckShield' },
+  { old: 'Favorite', new: 'Heart' },
+  { old: 'File', new: 'FileAdd' },
+  { old: 'Market', new: 'Sofa' },
+  { old: 'RatingEmpty', new:'StarEmpty' },
+  { old: 'RatingFull', new:'StarFull' },
+  { old: 'RatingHalf', new:'StarHalf' },
+  { old: 'PhoneNew', new:'Phone' },
+  { old: 'TableSortUp', new:'ArrowUp' },
+  { old: 'TableSortDown', new:'ArrowDown' },
+  { old: 'TorgetBrowser', new:'Browser' },
+  { old: 'TorgetDelivery', new:'Delivery' },
+  { old: 'TorgetHeadset', new:'Headset' },
+  { old: 'TorgetLamp', new:'Lamp' },
+  { old: 'TorgetShipping', new:'Shipping' },
+  { old: 'TorgetUsers', new:'UserGroup' },
+  { old: 'TorgetVerified', new:'Verified' },
+  { old: 'TorgetShopping', new:'ShoppingCart' },
+  { old: 'TorgetMixer', new:'Mixer' },
+  { old: 'Triangle', new:'warning' },
+  { old: 'Paw16', new:'AnimalPaw' },
+  { old: 'Paw24', new:'AnimalPaw' },
+  { old: 'Paw32', new:'AnimalPaw' },
+  { old: 'Car42', new: 'Minivan' },
+  { old: 'TableInfo', new:'Info' },
+  { old: 'Honk', new:'HonkLight' },
+  { old: 'Nettbil', new:'NettbilLight' }
+]
+
+const isDeprecated = (iconName) => deprecatedIcons.find(icon => iconName.includes(icon.old)) ? true : false;
+const getDeprecationMessage = (iconName) => `DEPRECATED - will be replaced with ${deprecatedIcons.find(icon => iconName.includes(icon.old)).new} icon in v2.0.0`
+
 const showModal = ref(false);
 let modalData = ref({
   iconName: "",
@@ -15,6 +50,7 @@ let modalData = ref({
   vueSyntax: "",
   elements: "",
   elementsIcon: "",
+  deprecationMessage: ""
 });
 
 const mappedIconsBySize = Object.keys(icons).reduce((acc, current) => {
@@ -48,6 +84,7 @@ const setIconData = (icon, fullName, event) => {
     vueSyntax: `<icon-${outputString} />`,
     elements: `import from '@warp-ds/icons/elements/${outputString}';`,
     elementsSyntax: `<w-icon-${outputString}></w-icon-${outputString}>`,
+    deprecationMessage: isDeprecated(fullName) && getDeprecationMessage(fullName),
   };
 };
 
@@ -61,6 +98,7 @@ const reset = () => {
     vueSyntax: "",
     elements: "",
     elementsSyntax: "",
+    deprecationMessage: "",
   };
 };
 </script>
@@ -82,9 +120,12 @@ const reset = () => {
       "
     >
       <div>
-        <h1 class="h4 mb-16">
+        <h2 class="t4 mb-16 text-center">
           You can use the following import for icon: {{ modalData.iconName }}
-        </h1>
+        </h2>
+        <p v-if="modalData.deprecationMessage" class="my-8 text-center s-text-negative">
+          {{ modalData.deprecationMessage }}
+        </p>
         <div class="mx-auto mb-8 s-bg border rounded-4 h-56 flex items-center justify-center flex-col">
           <component :is="modalData.icon" class="s-icon"></component>
         </div>
@@ -115,7 +156,7 @@ const reset = () => {
     <main class="max-w-screen-xl mx-auto px-32">
       <div class="grid gap-24 grid-cols-minmax-100px">
         <button
-          class="bg-transparent"
+          class="bg-transparent flex"
           @click="
             showModal = true;
             setIconData(icon, fullName, event);
@@ -123,7 +164,7 @@ const reset = () => {
           v-for="(icon, fullName) in mappedIconsBySize[size]"
           :key="fullName"
         >
-          <div class="text-center">
+          <div class="text-center flex-1">
             <div
               :class="{
                 'mx-auto mb-8 s-bg rounded-4 h-56 flex items-center justify-center flex-col': true,
@@ -134,6 +175,7 @@ const reset = () => {
             </div>
             <p class="text-12" style="color: var(--vp-c-text-1)">
               {{ getIconName(fullName) }}
+              {{ isDeprecated(fullName) ? 'DEPRECATED' : ''}}
             </p>
           </div>
         </button>

--- a/docs/components/icons/Example.vue
+++ b/docs/components/icons/Example.vue
@@ -125,7 +125,10 @@ const reset = () => {
         >
           <div class="text-center">
             <div
-              class="mx-auto mb-8 s-bg rounded-4 h-56 flex items-center justify-center flex-col"
+              :class="{
+                'mx-auto mb-8 s-bg rounded-4 h-56 flex items-center justify-center flex-col': true,
+                's-bg-inverted': fullName.includes('Dark')
+              }"
             >
               <component :is="icon" class="s-icon"></component>
             </div>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@warp-ds/css": "^1.6.1",
-    "@warp-ds/icons": "^1.4.0",
+    "@warp-ds/icons": "^1.5.0",
     "@warp-ds/react": "1.3.0",
     "@warp-ds/uno": "^1.3.0",
     "@warp-ds/vue": "^1.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ devDependencies:
     specifier: ^1.6.1
     version: 1.6.1
   '@warp-ds/icons':
-    specifier: ^1.4.0
-    version: 1.4.0
+    specifier: ^1.5.0
+    version: 1.5.0
   '@warp-ds/react':
     specifier: 1.3.0
     version: 1.3.0(react@18.2.0)
@@ -571,11 +571,28 @@ packages:
       unraw: 3.0.0
     dev: true
 
+  /@lingui/core@4.7.0:
+    resolution: {integrity: sha512-lr6CMDRztFgS5qna9pLA/MPZRgujN9SCIoQ1LvGZem94U4Qc7ptSwAG1LIET9b3qxRXJm5XOTrq0HefN2Qm1IA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@lingui/message-utils': 4.7.0
+      unraw: 3.0.0
+    dev: true
+
   /@lingui/message-utils@4.5.0:
     resolution: {integrity: sha512-iRqh2wvNtzJO3NStB77nEXEfeI53aVVjzD7/mBrEm/P0lC7sqPHk0WBQCfzE0N9xm6a+XHmHu3J+x2nnQ2OjcA==}
     engines: {node: '>=16.0.0'}
     dependencies:
       '@messageformat/parser': 5.1.0
+    dev: true
+
+  /@lingui/message-utils@4.7.0:
+    resolution: {integrity: sha512-JrGdxORRzefOh9qAkQYJchh+ehnWlLK9/kOG9x6VkV9aekWLk8vCVbXBh4Q707sTcIgCki8KwT1yuBMwZ2YBEg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@messageformat/parser': 5.1.0
+      js-sha256: 0.10.1
     dev: true
 
   /@messageformat/parser@5.1.0:
@@ -1111,6 +1128,12 @@ packages:
       '@lingui/core': 4.5.0
     dev: true
 
+  /@warp-ds/icons@1.5.0:
+    resolution: {integrity: sha512-HQ4OZ7XcG0FAFkFXFAPvkPw7yOvPuxGF6WNpM0s/czfn5ZQ4+rTyow87mkUodoizc6Nq4uP2Q5HRDnCDLRBXaQ==}
+    dependencies:
+      '@lingui/core': 4.7.0
+    dev: true
+
   /@warp-ds/react@1.3.0(react@18.2.0):
     resolution: {integrity: sha512-bs91ksdMu+/vloTOz+jKQYNInTabO9XLyZH/LO2gyasxx3o9yqaP5VSOtwaxfA+mubDU5qcOvgbUndFj/vKGHA==}
     peerDependencies:
@@ -1525,6 +1548,10 @@ packages:
   /jiti@1.21.0:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
     hasBin: true
+    dev: true
+
+  /js-sha256@0.10.1:
+    resolution: {integrity: sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==}
     dev: true
 
   /js-tokens@4.0.0:


### PR DESCRIPTION
Blocked by https://github.com/warp-ds/icons/pull/92 (waiting for Norwegian translations)

- update @warp-ds/icons to 1.5.0 to present the latest changes in the icons examples page
- fix icon examples to use inverted background when -dark icons are presented
<img width="288" alt="Screenshot 2024-02-02 at 10 57 54" src="https://github.com/warp-ds/tech-docs/assets/41303231/e264f234-ecfd-49b4-ad4c-4574a03c327b">

- add deprecation message for icons that will be removed in v2
<img width="291" alt="Screenshot 2024-02-02 at 10 54 33" src="https://github.com/warp-ds/tech-docs/assets/41303231/2420753d-1625-498f-8f34-4c58c72509c5">
<img width="620" alt="Screenshot 2024-02-02 at 13 39 16" src="https://github.com/warp-ds/tech-docs/assets/41303231/2e2782b6-b114-467d-bf6d-845ab8fa4399">
