### PR TITLE
chore(toast): remove closable toast example & update api docs

### DIFF
--- a/docs/api-table.js
+++ b/docs/api-table.js
@@ -1501,9 +1501,9 @@ export const elements = {
     required: [],
     props: [
       ['type', "'success' | 'warning' | 'error'", "'success'", 'Type of toast'],
-      ['text', 'string', 'undefined', 'Applies styling to indicate click-ability'],
-      ['duration', 'number', '5000', 'Auto removal of toast'],
-      ['canclose', 'boolean', 'false', 'Adds close button. WARNING! For accessibility reasons, toasts should not be interactive and canclose should always be false. If the toast absolutely must be dismissible, set this to true.'],
+      ['text', 'string', 'undefined', 'The toast message. Only needed when updating text on existing toast'],
+      ['duration', 'number', '5000', 'Duration of toast in milliseconds. For accessibility reasons, toasts should never be interactive and therefore need to auto remove. If you must disable auto remove, set duration to Number.POSITIVE_INFINITY.'],
+      ['canclose', 'boolean', 'false', 'Adds a close button. WARNING! For accessibility reasons, toasts should not be interactive and canclose should always be false. If the toast absolutely must be dismissible, set this to true.'],
     ]
   },
 };

--- a/docs/components/toast/Example.vue
+++ b/docs/components/toast/Example.vue
@@ -6,7 +6,7 @@
     </div>
     <div>
       <h3 class="h4">Warning</h3>
-      <img src="/toast_warning.png" alt="toast success" width="200"/>
+      <img src="/toast_warning.png" alt="toast warning" width="200"/>
     </div>
     <div>
       <h3 class="h4">Error</h3>

--- a/docs/components/toast/Example.vue
+++ b/docs/components/toast/Example.vue
@@ -10,7 +10,7 @@
     </div>
     <div>
       <h3 class="h4">Error</h3>
-      <img src="/toast_error.png" alt="toast success" width="200"/>
+      <img src="/toast_error.png" alt="toast error" width="200"/>
     </div>
   </div>
 </template>

--- a/docs/components/toast/Example.vue
+++ b/docs/components/toast/Example.vue
@@ -2,19 +2,15 @@
   <div class="component space-y-16">
     <div>
       <h3 class="h4">Success</h3>
-      <img src="/toast_success.png" alt="toast success can close" width="200"/>
+      <img src="/toast_success.png" alt="toast success" width="200"/>
     </div>
     <div>
       <h3 class="h4">Warning</h3>
-      <img src="/toast_warning.png" alt="toast success can close" width="200"/>
+      <img src="/toast_warning.png" alt="toast success" width="200"/>
     </div>
     <div>
       <h3 class="h4">Error</h3>
-      <img src="/toast_error.png" alt="toast success can close" width="200"/>
-    </div>
-    <div>
-      <h3 class="h4">Success with close button</h3>
-      <img src="/toast_success_close.png" alt="toast success can close" width="225"/>
+      <img src="/toast_error.png" alt="toast success" width="200"/>
     </div>
   </div>
 </template>

--- a/docs/components/toast/elements.md
+++ b/docs/components/toast/elements.md
@@ -9,7 +9,7 @@ Import functions for working with toasts:
 Be sure to import the elements package first as the toast APIs depend on this package.
 
 ```js
-import from '@warp-ds/elements'
+import '@warp-ds/elements';
 ```
 
 Once you have imported the elements package, import the toast api package.


### PR DESCRIPTION
Fixes [WARP-490](https://nmp-jira.atlassian.net/browse/WARP-490)

This PR removes a toast example that shows a close button inside and updates toast props docs based on [Fabric Toast descriptions](https://github.com/fabric-ds/elements/blob/next/packages/toast/api.js#L7-L9).
 
![Screenshot 2024-02-05 at 13 17 18](https://github.com/warp-ds/tech-docs/assets/41303231/808ddd8e-0bd2-4ee3-baf3-860b6020a73d)
