### PR TITLE
chore: update @warp-ds/icons to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@warp-ds/css": "1.9.4",
-    "@warp-ds/icons": "2.0.0",
+    "@warp-ds/icons": "2.0.1",
     "@warp-ds/react": "1.4.4",
     "@warp-ds/uno": "1.11.0",
     "@warp-ds/vue": "1.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,12 +1,16 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 devDependencies:
   '@warp-ds/css':
     specifier: 1.9.4
     version: 1.9.4
   '@warp-ds/icons':
-    specifier: 2.0.0
-    version: 2.0.0
+    specifier: 2.0.1
+    version: 2.0.1
   '@warp-ds/react':
     specifier: 1.4.4
     version: 1.4.4(react@18.2.0)
@@ -33,13 +37,13 @@ devDependencies:
     version: 1.75.0
   unocss:
     specifier: ^0.59.3
-    version: 0.59.3(vite@5.2.9)
+    version: 0.59.3(postcss@8.4.38)(vite@5.2.9)
   vite:
     specifier: ^5.2.9
     version: 5.2.9(sass@1.75.0)
   vitepress:
     specifier: 1.1.0
-    version: 1.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.75.0)
+    version: 1.1.0(postcss@8.4.38)(react-dom@18.2.0)(react@18.2.0)(sass@1.75.0)
   vue:
     specifier: ^3.4.22
     version: 3.4.22
@@ -1215,9 +1219,11 @@ packages:
       sirv: 2.0.4
     dev: true
 
-  /@unocss/postcss@0.59.3:
+  /@unocss/postcss@0.59.3(postcss@8.4.38):
     resolution: {integrity: sha512-lyRO8jHDYdAwL/pEdU6uSDfp/pps8pwYQfIh7OZN1BRASPv/ik7HVbRW4bsiMDaBHaxGkrvWATLXQ/W+iBkslw==}
     engines: {node: '>=14'}
+    peerDependencies:
+      postcss: ^8.4.21
     dependencies:
       '@unocss/config': 0.59.3
       '@unocss/core': 0.59.3
@@ -1586,6 +1592,12 @@ packages:
 
   /@warp-ds/icons@2.0.0:
     resolution: {integrity: sha512-a6Zi9CEunu5V0ScfaG42j5LoPK/U9uL5Gcv+/4D9FNQjaPuissqflUL3YpYI2PxTMIrHuyYXfUMWu8gBVGoUdg==}
+    dependencies:
+      '@lingui/core': 4.7.0
+    dev: true
+
+  /@warp-ds/icons@2.0.1:
+    resolution: {integrity: sha512-GYKgLePU6dVfWcBnfJEschXY0hQxy1ajsEuiJwcKRgN70pk9ZWICBfJbVI4NSlgdWbglgaptyjDj9B6ug4Jy6A==}
     dependencies:
       '@lingui/core': 4.7.0
     dev: true
@@ -2729,7 +2741,7 @@ packages:
       jiti: 1.21.0
     dev: true
 
-  /unocss@0.59.3(vite@5.2.9):
+  /unocss@0.59.3(postcss@8.4.38)(vite@5.2.9):
     resolution: {integrity: sha512-4Sos0FjDX5Ck/cV1wrTase0r2V/LI/bIncguisIGq9v7/akghsGEqU8LlxZNqoCug/vpcQICmzt/zclJVUT+GQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -2745,7 +2757,7 @@ packages:
       '@unocss/cli': 0.59.3
       '@unocss/core': 0.59.3
       '@unocss/extractor-arbitrary-variants': 0.59.3
-      '@unocss/postcss': 0.59.3
+      '@unocss/postcss': 0.59.3(postcss@8.4.38)
       '@unocss/preset-attributify': 0.59.3
       '@unocss/preset-icons': 0.59.3
       '@unocss/preset-mini': 0.59.3
@@ -2763,6 +2775,7 @@ packages:
       '@unocss/vite': 0.59.3(vite@5.2.9)
       vite: 5.2.9(sass@1.75.0)
     transitivePeerDependencies:
+      - postcss
       - rollup
       - supports-color
     dev: true
@@ -2847,7 +2860,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitepress@1.1.0(react-dom@18.2.0)(react@18.2.0)(sass@1.75.0):
+  /vitepress@1.1.0(postcss@8.4.38)(react-dom@18.2.0)(react@18.2.0)(sass@1.75.0):
     resolution: {integrity: sha512-G+NS5I2OETxC0SfGAMDO75JWNkrcir0UCptuhQMNoaZhhlqvYtTDQhph4qGc5dtiTtZkcFa/bCcSx+A2gSS3lA==}
     hasBin: true
     peerDependencies:
@@ -2871,6 +2884,7 @@ packages:
       focus-trap: 7.5.4
       mark.js: 8.11.1
       minisearch: 6.3.0
+      postcss: 8.4.38
       shiki: 1.3.0
       vite: 5.2.9(sass@1.75.0)
       vue: 3.4.22
@@ -2971,7 +2985,3 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
<img width="332" alt="Screenshot of AutovexDark and AutovexLight icon" src="https://github.com/warp-ds/tech-docs/assets/41303231/342bcb85-74eb-4bf7-958c-7da9f5579ae3">
