### PR TITLE
chore(deps): udpate @warp-ds/icons to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@warp-ds/css": "1.9.7",
-    "@warp-ds/icons": "2.0.1",
+    "@warp-ds/icons": "2.0.2",
     "@warp-ds/react": "1.5.0",
     "@warp-ds/uno": "1.12.0",
     "@warp-ds/vue": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 1.9.7
         version: 1.9.7
       '@warp-ds/icons':
-        specifier: 2.0.1
-        version: 2.0.1
+        specifier: 2.0.2
+        version: 2.0.2
       '@warp-ds/react':
         specifier: 1.5.0
         version: 1.5.0(@floating-ui/dom@1.6.3)(react@18.3.1)
@@ -840,8 +840,8 @@ packages:
   '@warp-ds/icons@2.0.0':
     resolution: {integrity: sha512-a6Zi9CEunu5V0ScfaG42j5LoPK/U9uL5Gcv+/4D9FNQjaPuissqflUL3YpYI2PxTMIrHuyYXfUMWu8gBVGoUdg==}
 
-  '@warp-ds/icons@2.0.1':
-    resolution: {integrity: sha512-GYKgLePU6dVfWcBnfJEschXY0hQxy1ajsEuiJwcKRgN70pk9ZWICBfJbVI4NSlgdWbglgaptyjDj9B6ug4Jy6A==}
+  '@warp-ds/icons@2.0.2':
+    resolution: {integrity: sha512-TxhE5JR459zCpFf132t6MZw2A1/4uC4/B4iq+00UgkJJXOssO7xAxc+Yg9q4D5lvnep4iItO5UR+6oDZA5ZTcA==}
 
   '@warp-ds/react@1.5.0':
     resolution: {integrity: sha512-ZIn1pg9mPKpR5De4gDlxty5otRrJGX5ADbJQVIKUF4F8jaJ/XXr4+z/8hro+vWSZIl/C6yh30EUXc2q2glB3vA==}
@@ -2483,7 +2483,7 @@ snapshots:
     dependencies:
       '@lingui/core': 4.10.1
 
-  '@warp-ds/icons@2.0.1':
+  '@warp-ds/icons@2.0.2':
     dependencies:
       '@lingui/core': 4.10.1
 


### PR DESCRIPTION
Fixes stroke width of `users` icon in 32px size.

Before:
<img width="164" alt="Screenshot of users icon with regular stroke width" src="https://github.com/warp-ds/tech-docs/assets/41303231/8a8b875b-a338-4351-916f-5bb921b8916c">

After:
<img width="168" alt="Screenshot of users icon with bolder stroke width" src="https://github.com/warp-ds/tech-docs/assets/41303231/3aa7ff64-1d5d-4be9-8d1d-c46505341b11">

