### PR TITLE
chore(deps): update @warp-ds/icons to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@unocss/core": "0.61.5",
     "@vueuse/core": "10.11.0",
     "@warp-ds/css": "2.0.0",
-    "@warp-ds/icons": "2.1.0",
+    "@warp-ds/icons": "2.2.0",
     "@warp-ds/preset-docs": "0.0.16",
     "@warp-ds/react": "2.0.1",
     "@warp-ds/uno": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0(@warp-ds/uno@2.0.0(unocss@0.61.5(postcss@8.4.39)(rollup@4.18.0)(vite@5.3.5(sass@1.77.8))))
       '@warp-ds/icons':
-        specifier: 2.1.0
-        version: 2.1.0
+        specifier: 2.2.0
+        version: 2.2.0
       '@warp-ds/preset-docs':
         specifier: 0.0.16
         version: 0.0.16(@warp-ds/uno@2.0.0(unocss@0.61.5(postcss@8.4.39)(rollup@4.18.0)(vite@5.3.5(sass@1.77.8))))
@@ -881,6 +881,9 @@ packages:
 
   '@warp-ds/icons@2.1.0':
     resolution: {integrity: sha512-PpecGJRqOVimnsfh5dfl7+4Ai8D8SqiMVwgSfy4b5KVLtRspN9jR/BaMEcDjDa7011Hucn61wB9LwKVbNfEfdg==}
+
+  '@warp-ds/icons@2.2.0':
+    resolution: {integrity: sha512-mkD69w5fsvsqDZr1a1LQkJBW24XyuNfpCGq4y3nesOuhhkteWetBplCFOaQ+S+77DJOTfWqxDcu1up/CbTC3lg==}
 
   '@warp-ds/preset-docs@0.0.16':
     resolution: {integrity: sha512-R4gsVtPcvYZ0LWGKGzEYuuRo+Iy8HIlSFCUwSt0MEmXtk4pCslDlxX/c2GJarUnAt6h86PUDCyAaUbHfPHAFOg==}
@@ -2496,6 +2499,8 @@ snapshots:
       '@warp-ds/uno': 2.0.0(unocss@0.61.5(postcss@8.4.39)(rollup@4.18.0)(vite@5.3.5(sass@1.77.8)))
 
   '@warp-ds/icons@2.1.0': {}
+
+  '@warp-ds/icons@2.2.0': {}
 
   '@warp-ds/preset-docs@0.0.16(@warp-ds/uno@2.0.0(unocss@0.61.5(postcss@8.4.39)(rollup@4.18.0)(vite@5.3.5(sass@1.77.8))))':
     dependencies:


### PR DESCRIPTION
This PR updates @warp-ds/icons to 2.2.0, which automatically documents fixes from [WARP-620](https://nmp-jira.atlassian.net/browse/WARP-620), like these new icons:
<img width="117" alt="Football icon" src="https://github.com/user-attachments/assets/9dc6f922-451d-494f-bb9d-a4ceb2836847"><img width="119" alt="Sparkles icon" src="https://github.com/user-attachments/assets/078477af-2941-471b-9286-f0d82d749f07"><img width="392" alt="TrendDown, TrendFlat and TrendUp icons" src="https://github.com/user-attachments/assets/4dfe2b07-5db6-4ff7-8384-66f723213c4e">
